### PR TITLE
Fixed ec2user-jupyter-config.sh to install correct version of jupyterlab

### DIFF
--- a/blogpost/cloudformation/ec2user-jupyter-config.sh
+++ b/blogpost/cloudformation/ec2user-jupyter-config.sh
@@ -5,7 +5,8 @@ export PATH=/home/ec2-user/anaconda3/bin:$PATH
 curl -sL https://rpm.nodesource.com/setup_15.x | sudo bash -
 sudo yum install -y nodejs
 pip install --upgrade jupyter
-pip install --upgrade jupyterlab
+pip uninstall jupyterlab
+pip install "jupyterlab>=2.2.9,<3.0.0"
 pip install aws-jupyter-proxy
 
 npm_version=`npm --version`


### PR DESCRIPTION
Current guide installs latest version of jupyterlab, which is as of writing 3.0.1. Jupyterlab version 3.x is not supported by the databrew jupyter extension. This fix updates jupyterlab installation to version `>=2.2.9,<3.0.0`.