### PR TITLE
Fixed compatibility issues with jupyter 1.2.x

### DIFF
--- a/lib/LeftSideLauncher.d.ts
+++ b/lib/LeftSideLauncher.d.ts
@@ -1,0 +1,21 @@
+import { Widget as PhosphorWidget } from '@phosphor/widgets';
+import { CommandRegistry as PhosphorCommandRegistry } from '@phosphor/commands';
+import { Widget as LuminoWidget } from '@lumino/widgets';
+import { CommandRegistry as LuminoCommandRegistry } from '@lumino/commands';
+export declare class PhosphorLeftSideLauncher extends PhosphorWidget {
+    /**
+     * Command Registry
+     */
+    commands: PhosphorCommandRegistry;
+    handleLaunchButtonClicked(): void;
+}
+export declare class LuminoLeftSideLauncher extends LuminoWidget {
+    /**
+     * Command Registry
+     */
+    commands: LuminoCommandRegistry;
+    handleLaunchButtonClicked(): void;
+}
+export declare class LeftSideLauncher {
+    static create(version: number, commands: PhosphorCommandRegistry | LuminoCommandRegistry): PhosphorLeftSideLauncher | LuminoLeftSideLauncher;
+}

--- a/lib/LeftSideLauncher.js
+++ b/lib/LeftSideLauncher.js
@@ -1,0 +1,33 @@
+import { Widget as PhosphorWidget, } from '@phosphor/widgets';
+import { Widget as LuminoWidget, } from '@lumino/widgets';
+import { GLUE_DATABREW_RENDER } from './constants';
+export class PhosphorLeftSideLauncher extends PhosphorWidget {
+    handleLaunchButtonClicked() {
+        this.commands.execute(GLUE_DATABREW_RENDER);
+    }
+}
+export class LuminoLeftSideLauncher extends LuminoWidget {
+    handleLaunchButtonClicked() {
+        this.commands.execute(GLUE_DATABREW_RENDER);
+    }
+}
+export class LeftSideLauncher {
+    static create(version, commands) {
+        const widget = version === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
+        widget.commands = commands;
+        const launchButton = document.createElement('div');
+        const header = document.createElement('header');
+        header.className = 'aws_glue_databrew_header';
+        header.textContent = 'AWS Glue DataBrew';
+        launchButton.title = 'Welcome to AWS Glue DataBrew';
+        launchButton.id = 'aws_glue_databrew_launch_button';
+        launchButton.textContent = 'Launch AWS Glue DataBrew';
+        launchButton.onclick = widget.handleLaunchButtonClicked.bind(widget);
+        widget.node.appendChild(header);
+        widget.node.appendChild(launchButton);
+        widget.id = 'aws_glue_databrew_jupyter_left_side_launcher';
+        widget.title.iconClass = 'jp-databrew-logo jp-SideBar-tabIcon';
+        widget.title.caption = 'AWS Glue DataBrew';
+        return widget;
+    }
+}

--- a/lib/MainLauncher.d.ts
+++ b/lib/MainLauncher.d.ts
@@ -1,0 +1,25 @@
+import { Widget as PhosphorWidget } from '@phosphor/widgets';
+import { Widget as LuminoWidget } from '@lumino/widgets';
+export declare class PhosphorMainLauncher extends PhosphorWidget {
+    /**
+     * The image element associated with the widget.
+     */
+    consoleRoot: HTMLElement;
+    /**
+     * A path to css assets
+     */
+    cssPath: string;
+}
+export declare class LuminoMainLauncher extends LuminoWidget {
+    /**
+     * The image element associated with the widget.
+     */
+    consoleRoot: HTMLElement;
+    /**
+     * A path to css assets
+     */
+    cssPath: string;
+}
+export declare class MainLauncher {
+    static create(version: number, cssPath: string): PhosphorMainLauncher | LuminoMainLauncher;
+}

--- a/lib/MainLauncher.js
+++ b/lib/MainLauncher.js
@@ -1,0 +1,71 @@
+import { Widget as PhosphorWidget, } from '@phosphor/widgets';
+import { Widget as LuminoWidget, } from '@lumino/widgets';
+export class PhosphorMainLauncher extends PhosphorWidget {
+}
+export class LuminoMainLauncher extends LuminoWidget {
+}
+export class MainLauncher {
+    static create(version, cssPath) {
+        const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
+        widget.cssPath = cssPath;
+        widget.id = 'aws_glue_databrew_jupyter';
+        widget.title.label = 'AWS Glue DataBrew';
+        widget.title.closable = true;
+        widget.consoleRoot = document.createElement('html');
+        widget.consoleRoot.setAttribute('style', 'height: 100%');
+        widget.node.appendChild(widget.consoleRoot);
+        widget.consoleRoot.insertAdjacentHTML('beforeend', `
+        <head>
+          <meta charset="UTF-8">
+          <meta name="awsc-lang" content="en">
+          <meta name="aws-glue-databrew-jupyter" content="true">
+          <title>AWS</title>
+          <link rel="stylesheet" href=` + cssPath + `>
+          <style>
+            .loader {
+              display: inline-block;
+              border: 5px solid #f3f3f3;
+              border-radius: 50%;
+              border-top: 5px solid #3498db;
+              width: 40px;
+              height: 40px;
+              margin-right: 12px;
+              -webkit-animation: spin 2s linear infinite;
+              animation: spin 2s linear infinite;
+            }
+
+            @-webkit-keyframes spin {
+              0% { -webkit-transform: rotate(0deg); }
+              100% { -webkit-transform: rotate(360deg); }
+            }
+
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+
+            .loader-container {
+              font-size: 60px;
+              font-weight: 100;
+              color: #879196;
+              height: 100%;
+              width: 100%;
+              justify-content: center;
+              display: flex;
+              align-items: center;
+            }
+          </style>
+        </head>
+        <body style="height: 100%">
+          <div id="app" style="height: 100%">
+            <div class="loader-container">
+              <div>
+                <div class="loader"></div><span>Launching AWS Glue DataBrew</span>
+              </div>
+            </div>
+          </div>
+        </body>
+    `);
+        return widget;
+    }
+}

--- a/lib/aws_glue_databrew_extension.d.ts
+++ b/lib/aws_glue_databrew_extension.d.ts
@@ -1,37 +1,5 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { Widget } from '@lumino/widgets';
-import { CommandRegistry } from '@lumino/commands';
-declare type GetPathsFunction = () => Promise<string[]>;
-/**
- * Left side launcher widget
- */
-export declare class LeftSideLauncherWidget extends Widget {
-    /**
-     * Command Registry
-     */
-    commands: CommandRegistry;
-    constructor(commands: CommandRegistry);
-    handleLaunchButtonClicked(): void;
-}
-/**
- * A GlueDataBrew console viewer.
- */
-export declare class GlueDataBrewConsoleWidget extends Widget {
-    /**
-     * The image element associated with the widget.
-     */
-    readonly consoleRoot: HTMLElement;
-    /**
-     * A path to css assets
-     */
-    readonly cssPath: string;
-    /**
-     * Construct a new glue databrew console widget.
-     */
-    constructor(cssPath: string);
-}
 /**
  * Initialize the console widget extension
  */
-export declare const initiateExtension: (getPaths: GetPathsFunction) => JupyterFrontEndPlugin<void>;
-export {};
+export declare const initiateExtension: (getPaths: () => Promise<string[]>) => JupyterFrontEndPlugin<void>;

--- a/lib/aws_glue_databrew_extension.js
+++ b/lib/aws_glue_databrew_extension.js
@@ -1,117 +1,22 @@
-import { ILayoutRestorer } from '@jupyterlab/application';
+import { ILayoutRestorer, } from '@jupyterlab/application';
 import { ICommandPalette, } from '@jupyterlab/apputils';
-import { ILauncher } from '@jupyterlab/launcher';
-import { Widget, } from '@lumino/widgets';
-import { LabIcon } from '@jupyterlab/ui-components';
-import DATABREW_ICON from '../style/icons/databrew.svg';
-const GLUE_DATABREW_RENDER = 'gluedatabrew:render';
-/**
- * Left side launcher widget
- */
-export class LeftSideLauncherWidget extends Widget {
-    constructor(commands) {
-        super();
-        this.commands = commands;
-        const launchButton = document.createElement('div');
-        const header = document.createElement('header');
-        header.className = 'aws_glue_databrew_header';
-        header.textContent = 'AWS Glue DataBrew';
-        launchButton.title = 'Welcome to AWS Glue DataBrew';
-        launchButton.id = 'aws_glue_databrew_launch_button';
-        launchButton.textContent = 'Launch AWS Glue DataBrew';
-        launchButton.onclick = this.handleLaunchButtonClicked.bind(this);
-        this.node.appendChild(header);
-        this.node.appendChild(launchButton);
-    }
-    handleLaunchButtonClicked() {
-        this.commands.execute(GLUE_DATABREW_RENDER);
-    }
-}
-/**
- * A GlueDataBrew console viewer.
- */
-export class GlueDataBrewConsoleWidget extends Widget {
-    /**
-     * Construct a new glue databrew console widget.
-     */
-    constructor(cssPath) {
-        super();
-        this.cssPath = cssPath;
-        this.id = 'aws_glue_databrew_jupyter';
-        this.title.label = 'AWS Glue DataBrew';
-        this.title.closable = true;
-        this.consoleRoot = document.createElement('html');
-        this.consoleRoot.setAttribute('style', 'height: 100%');
-        this.node.appendChild(this.consoleRoot);
-        this.consoleRoot.insertAdjacentHTML('beforeend', `
-        <head>
-          <meta charset="UTF-8">
-          <meta name="awsc-lang" content="en">
-          <meta name="aws-glue-databrew-jupyter" content="true">
-          <title>AWS</title>
-          <link rel="stylesheet" href=` + cssPath + `>
-          <style>
-            .loader {
-              display: inline-block;
-              border: 5px solid #f3f3f3;
-              border-radius: 50%;
-              border-top: 5px solid #3498db;
-              width: 40px;
-              height: 40px;
-              margin-right: 12px;
-              -webkit-animation: spin 2s linear infinite;
-              animation: spin 2s linear infinite;
-            }
-
-            @-webkit-keyframes spin {
-              0% { -webkit-transform: rotate(0deg); }
-              100% { -webkit-transform: rotate(360deg); }
-            }
-
-            @keyframes spin {
-              0% { transform: rotate(0deg); }
-              100% { transform: rotate(360deg); }
-            }
-
-            .loader-container {
-              font-size: 60px;
-              font-weight: 100;
-              color: #879196;
-              height: 100%;
-              width: 100%;
-              justify-content: center;
-              display: flex;
-              align-items: center;
-            }
-          </style>
-        </head>
-        <body style="height: 100%">
-          <div id="app" style="height: 100%">
-            <div class="loader-container">
-              <div>
-                <div class="loader"></div><span>Launching AWS Glue DataBrew</span>
-              </div>
-            </div>
-          </div>
-        </body>
-    `);
-    }
-}
+import { ILauncher, } from '@jupyterlab/launcher';
+import { GLUE_DATABREW_RENDER } from './constants';
+import { LeftSideLauncher, } from './LeftSideLauncher';
+import { MainLauncher, } from './MainLauncher';
+const getAppVersion = (app) => Number(app.version.split('.')[0]);
 /**
  * Initialize the console widget extension
  */
 export const initiateExtension = (getPaths) => {
     const activate = async (app, palette, restorer, launcher) => {
+        const version = getAppVersion(app);
         // Declare a widget variable
         const [jsPath, cssPath] = await getPaths();
-        const consoleWidget = new GlueDataBrewConsoleWidget(cssPath);
-        const databrewIcon = new LabIcon({
-            name: 'gluedatabrew:icon',
-            svgstr: DATABREW_ICON
-        });
+        const consoleWidget = MainLauncher.create(version, cssPath);
         app.commands.addCommand(GLUE_DATABREW_RENDER, {
             label: 'Launch AWS Glue DataBrew',
-            icon: databrewIcon,
+            icon: 'jp-databrew-logo',
             execute: () => {
                 if (!consoleWidget.isAttached) {
                     app.shell.add(consoleWidget, 'main');
@@ -122,10 +27,7 @@ export const initiateExtension = (getPaths) => {
                 app.shell.activateById(consoleWidget.id);
             },
         });
-        const launcherWidget = new LeftSideLauncherWidget(app.commands);
-        launcherWidget.id = 'aws_glue_databrew_jupyter_left_side_launcher';
-        launcherWidget.title.iconClass = 'jp-databrew-logo jp-SideBar-tabIcon';
-        launcherWidget.title.caption = 'AWS Glue DataBrew';
+        const launcherWidget = LeftSideLauncher.create(version, app.commands);
         restorer.add(launcherWidget, launcherWidget.id);
         app.shell.add(launcherWidget, 'left');
         // Add the command to the palette.

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,0 +1,1 @@
+export declare const GLUE_DATABREW_RENDER = "gluedatabrew:render";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,1 @@
+export const GLUE_DATABREW_RENDER = 'gluedatabrew:render';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,1385 +1,23 @@
 {
   "name": "aws_glue_databrew_jupyter",
   "version": "1.0.2",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "aws_glue_databrew_jupyter",
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@jupyterlab/application": "^2.0.0",
-        "@jupyterlab/launcher": "^2.2.6",
-        "@lumino/commands": "^1.11.3",
-        "@lumino/widgets": "^1.13.3"
-      },
-      "devDependencies": {
-        "rimraf": "^3.0.0",
-        "tsc-watch": "^4.0.0",
-        "typescript": "~3.7.3"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@blueprintjs/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-/fBhPmQ1AJ7ATGzA9YBlnxN8KV7PjNeW9KL+IOWiERUNcF9kuiuKJ88hTs7gSSHNtHmCF+jheD+X0MQq4WYVjA==",
-      "dependencies": {
-        "@blueprintjs/icons": "^3.19.0",
-        "@types/dom4": "^2.0.1",
-        "classnames": "^2.2",
-        "dom4": "^2.1.5",
-        "normalize.css": "^8.0.1",
-        "popper.js": "^1.16.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-popper": "^1.3.7",
-        "react-transition-group": "^2.9.0",
-        "resize-observer-polyfill": "^1.5.1",
-        "tslib": "~1.10.0"
-      }
-    },
-    "node_modules/@blueprintjs/icons": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.19.0.tgz",
-      "integrity": "sha512-pFgEdSDj8q8ESofuXXSfonsiiqQNJ0u54vr8zxQyKggSwgMyASM/h9MdFVED7jXaj5nsda4or+hWM1ilUeES4Q==",
-      "dependencies": {
-        "classnames": "^2.2",
-        "tslib": "~1.10.0"
-      }
-    },
-    "node_modules/@blueprintjs/select": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.13.5.tgz",
-      "integrity": "sha512-GFdLhmD23JvWueLNDBZjE5+Kii1zT/R7vx/Ta5fPv3gdSnUBMyGZMkQAjKWrn7o7xyOE1im5G2A0sdhcfcs3iw==",
-      "dependencies": {
-        "@blueprintjs/core": "^3.30.0",
-        "classnames": "^2.2",
-        "tslib": "~1.10.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
-      "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
-    },
-    "node_modules/@jupyterlab/application": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.2.0.tgz",
-      "integrity": "sha512-dayndJ2MahAORRMDrersVvANmOded5GkKKShUAq/8C24bRkKd8zb/U4IpG1Ge93NWVW6ATHjRst6LxkiR+biOA==",
-      "dependencies": {
-        "@fortawesome/fontawesome-free": "^5.12.0",
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/docregistry": "^2.2.0",
-        "@jupyterlab/rendermime": "^2.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/statedb": "^2.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/application": "^1.8.4",
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/polling": "^1.1.1",
-        "@lumino/properties": "^1.1.6",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1"
-      }
-    },
-    "node_modules/@jupyterlab/apputils": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-2.2.6.tgz",
-      "integrity": "sha512-aWg0c6edfQC6b1sLFskirG+LqH1aGKnVGj7R7HR1loyOLVVq/HpZ9wkPZLCh8Gi1Wy4Tqvm2R46glmuu84W8xA==",
-      "dependencies": {
-        "@jupyterlab/coreutils": "^4.2.5",
-        "@jupyterlab/services": "^5.2.5",
-        "@jupyterlab/settingregistry": "^2.2.5",
-        "@jupyterlab/statedb": "^2.2.5",
-        "@jupyterlab/ui-components": "^2.2.4",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/domutils": "^1.1.7",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/properties": "^1.1.6",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/virtualdom": "^1.6.1",
-        "@lumino/widgets": "^1.11.1",
-        "@types/react": "~16.9.16",
-        "react": "~16.9.0",
-        "react-dom": "~16.9.0",
-        "sanitize-html": "~1.20.1"
-      }
-    },
-    "node_modules/@jupyterlab/codeeditor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.2.0.tgz",
-      "integrity": "sha512-BIvvznUEGJ+sjmiyxEKr7OC9O2jDO9mCpoFMV0koPQuQEz/241JltuskM+BeP81CIIyP9yq3Le6qXttsq7dXDQ==",
-      "dependencies": {
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/dragdrop": "^1.5.1",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1"
-      }
-    },
-    "node_modules/@jupyterlab/codemirror": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.2.0.tgz",
-      "integrity": "sha512-mErh3xhemsUWxgDVxwYxaPmrKruXF0ks/GaRJyfbrTA/m8KnAf4jEbCISXeZTQ31EWAjdmkfUO35TVWvFCQYmg==",
-      "dependencies": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/statusbar": "^2.2.0",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/polling": "^1.1.1",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1",
-        "codemirror": "~5.53.2",
-        "react": "~16.9.0"
-      }
-    },
-    "node_modules/@jupyterlab/coreutils": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-4.2.5.tgz",
-      "integrity": "sha512-dkU9aD10vthsDulq1o5CEgIu0pe84v2Krxvfu3m4EYC+pSJmGHsxc3wmnb8MQocPiMJFB79brm6zJaXiy68uWA==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/signaling": "^1.3.5",
-        "minimist": "~1.2.0",
-        "moment": "^2.24.0",
-        "path-posix": "~1.0.0",
-        "url-parse": "~1.4.7"
-      }
-    },
-    "node_modules/@jupyterlab/docregistry": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.2.0.tgz",
-      "integrity": "sha512-jIjZ+YXYoNtTcZzfNBrf/1VNxLTSiMasaOB9jUsgVy6Z3MYuPrRobBp29ovVoTx8s/xe7sEbJr3MHIepJmuZxw==",
-      "dependencies": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/codemirror": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/rendermime": "^2.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1"
-      }
-    },
-    "node_modules/@jupyterlab/launcher": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-2.2.6.tgz",
-      "integrity": "sha512-oZx0ODAS0e6U2L/O4q/hXwHN9XWJ5z1RYDlMoczU8ZelJvvgg2AezkEWBJjFe5trbbndm4/kuQKtiLdENpDmUA==",
-      "dependencies": {
-        "@jupyterlab/apputils": "^2.2.6",
-        "@jupyterlab/ui-components": "^2.2.4",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/properties": "^1.1.6",
-        "@lumino/widgets": "^1.11.1",
-        "react": "~16.9.0"
-      }
-    },
-    "node_modules/@jupyterlab/nbformat": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-2.2.5.tgz",
-      "integrity": "sha512-NXxNDMB0n0GJS634KkqZBAS9tAFkkLubv2YfPkWLOjlYHWPclknQfMLWpjn2VTSdj7C+xk6qqsv4YLziRn5BPA==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.4.2"
-      }
-    },
-    "node_modules/@jupyterlab/observables": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-3.2.5.tgz",
-      "integrity": "sha512-21y72DScc4EsfcPpVgm4VLUcUWi2AvHuBOtrjPpNxrvrl3hNqTVNOOtX1lEeqVOzdWEJAJ7jeEe96rTkY5tptQ==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/signaling": "^1.3.5"
-      }
-    },
-    "node_modules/@jupyterlab/rendermime": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.2.0.tgz",
-      "integrity": "sha512-wTls25TElx0iAjALKxgWyLW+QGFCAXnyH0XiGkQULrbUauRuoArPQ1hKMcz4KL6XJjydMg6s9cqV9gQ9o3yJ8Q==",
-      "dependencies": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codemirror": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1",
-        "lodash.escape": "^4.0.1",
-        "marked": "^0.8.0"
-      }
-    },
-    "node_modules/@jupyterlab/rendermime-interfaces": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.2.0.tgz",
-      "integrity": "sha512-2gdYvRzq+IfOKgI751aZY9Gr8of3UeVZ03O2nLyiSlHa6lWhKuzXDPPrKk3NiToOlc2rJSUy+Y9Oj+TONjfvKg==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/widgets": "^1.11.1"
-      }
-    },
-    "node_modules/@jupyterlab/services": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-5.2.5.tgz",
-      "integrity": "sha512-vhWt+rbDUe3SRvv1GD1WOjsDNhDz2lg33xdsT/+WObZRqeQ9CgzUF2K8Zah9UaiyGmTM3tpUUCTIQ62hNi5wrA==",
-      "dependencies": {
-        "@jupyterlab/coreutils": "^4.2.5",
-        "@jupyterlab/nbformat": "^2.2.5",
-        "@jupyterlab/observables": "^3.2.5",
-        "@jupyterlab/settingregistry": "^2.2.5",
-        "@jupyterlab/statedb": "^2.2.5",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/polling": "^1.1.1",
-        "@lumino/signaling": "^1.3.5",
-        "node-fetch": "^2.6.0",
-        "ws": "^7.2.0"
-      }
-    },
-    "node_modules/@jupyterlab/settingregistry": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-2.2.5.tgz",
-      "integrity": "sha512-LoKa27F1WNmeMT168TYo+MgjsYsVawKCZbmU7OGQS6h6J5dx0xQBQvE38NkhCsjnPYyUv4tYmGIFyHQceCDDaA==",
-      "dependencies": {
-        "@jupyterlab/statedb": "^2.2.5",
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/signaling": "^1.3.5",
-        "ajv": "^6.10.2",
-        "json5": "^2.1.1"
-      }
-    },
-    "node_modules/@jupyterlab/statedb": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-2.2.5.tgz",
-      "integrity": "sha512-+hW1bQ6+p18SNZvjM7hZMPv7odkLWkAp17qoRPtky3j+CFnZW7m49U0XA8QezjLBiX9QdHFYgoUhIZEmrKcPDg==",
-      "dependencies": {
-        "@lumino/commands": "^1.10.1",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/properties": "^1.1.6",
-        "@lumino/signaling": "^1.3.5"
-      }
-    },
-    "node_modules/@jupyterlab/statusbar": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.2.0.tgz",
-      "integrity": "sha512-W4gv0kIgqT4nQcctCi8Bb2Wutdcdsy1GMd6fuP/fCRAUqSoDyIGesC1nx/V8+GBEgzBAehSQhFi+4P6Opo6ZyQ==",
-      "dependencies": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
-        "@lumino/algorithm": "^1.2.3",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/disposable": "^1.3.5",
-        "@lumino/messaging": "^1.3.3",
-        "@lumino/polling": "^1.1.1",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/widgets": "^1.11.1",
-        "csstype": "~2.6.9",
-        "react": "~16.9.0",
-        "typestyle": "^2.0.4"
-      }
-    },
-    "node_modules/@jupyterlab/ui-components": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-2.2.4.tgz",
-      "integrity": "sha512-8OqmlDIlf3OHrKqTGHLBbzY6gDyTGT91o5LSyLuOBhIF2TvPorBYnxWk883pO7n4rSVhZbafBb0U3Hl3X9uT3Q==",
-      "dependencies": {
-        "@blueprintjs/core": "^3.22.2",
-        "@blueprintjs/select": "^3.11.2",
-        "@jupyterlab/coreutils": "^4.2.5",
-        "@lumino/coreutils": "^1.4.2",
-        "@lumino/signaling": "^1.3.5",
-        "@lumino/virtualdom": "^1.6.1",
-        "@lumino/widgets": "^1.11.1",
-        "react": "~16.9.0",
-        "react-dom": "~16.9.0",
-        "typestyle": "^2.0.4"
-      },
-      "peerDependencies": {
-        "react": "~16.9.0"
-      }
-    },
-    "node_modules/@lumino/algorithm": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.3.3.tgz",
-      "integrity": "sha512-I2BkssbOSLq3rDjgAC3fzf/zAIwkRUnAh60MO0lYcaFdSGyI15w4K3gwZHGIO0p9cKEiNHLXKEODGmOjMLOQ3g=="
-    },
-    "node_modules/@lumino/application": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.10.3.tgz",
-      "integrity": "sha512-YYIDmgfYqLfejVYTKSjfIVttyeklSmqepbESHVMj1M1rFLvUlb8DQtS0xFpqVJElpnYAAiIUmGzYMMX5529+rQ==",
-      "dependencies": {
-        "@lumino/commands": "^1.11.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/widgets": "^1.13.3"
-      }
-    },
-    "node_modules/@lumino/collections": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.3.3.tgz",
-      "integrity": "sha512-vN3GSV5INkgM6tMLd+WqTgaPnQNTY7L/aFUtTOC8TJQm+vg1eSmR4fNXsoGHM3uA85ctSJThvdZr5triu1Iajg==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3"
-      }
-    },
-    "node_modules/@lumino/commands": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.11.3.tgz",
-      "integrity": "sha512-0JencVUzJWEaXVDngpLhgOWza6Yql5tq2W2Qsi9U3exEDE3CqXdjehI/Uy4Cj2+aAfZju8iPvyZVlLq2psyKLw==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/keyboard": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.7.3"
-      }
-    },
-    "node_modules/@lumino/coreutils": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.5.3.tgz",
-      "integrity": "sha512-G72jJ6sgOwAUuilz+cri7LpHIJxllK+qz+YZUC3fyyWHK7oRlZemcc43jZAVE+tagTdMxKYSQWNIVzM5lI8sWw=="
-    },
-    "node_modules/@lumino/disposable": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.4.3.tgz",
-      "integrity": "sha512-zKQ9N2AEGcYpG6PJkeMWQXvoXU9w1ocji78z+fboM/SmSgtOIVGeQt3fZeldymf0XrlOPpNXs1ZFg54yWUMnXA==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/signaling": "^1.4.3"
-      }
-    },
-    "node_modules/@lumino/domutils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.2.3.tgz",
-      "integrity": "sha512-SEi8WZSy+DWMkL5CfAY78MHbi3x83AVmRFxjs9+A6qsFPde+Hr1I4DNtLsSDmfAWsobHHgBnjyNp2ZkQEq0IEA=="
-    },
-    "node_modules/@lumino/dragdrop": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.6.3.tgz",
-      "integrity": "sha512-24SH+CA6N+cNePVKDRfOnphmYwByyRtxi7eH8bA5h4rY1cqyvMTLT6wA0yLFPQJ8c2pE0xZNZKxSc7iy4jhaaQ==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3"
-      }
-    },
-    "node_modules/@lumino/keyboard": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.2.3.tgz",
-      "integrity": "sha512-ibS0sz0VABeuJXx2JVSz36sUBMUOcQNCNPybVhwzN/GkJFs0dnDKluMu+3Px0tkB2y33bGPZU/RLZY1Xj/faEA=="
-    },
-    "node_modules/@lumino/messaging": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.4.3.tgz",
-      "integrity": "sha512-wa2Pj2KOuLNLS2n0wVBzUVFGbvjL1FLbuCOAUEYfN6xXVleqqtGGzd08uTF7ebu01KCO3VQ38+dkvoaM/C2qPw==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/collections": "^1.3.3"
-      }
-    },
-    "node_modules/@lumino/polling": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.3.3.tgz",
-      "integrity": "sha512-uMRi6sPRnKW8m38WUY3qox1jxwzpvceafUbDJATCwyrZ48+YoY5Fxfmd9dqwioHS1aq9np5c6L35a9ZGuS0Maw==",
-      "dependencies": {
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/signaling": "^1.4.3"
-      }
-    },
-    "node_modules/@lumino/properties": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.2.3.tgz",
-      "integrity": "sha512-dbS9V/L+RpQoRjxHMAGh1JYoXaLA6F7xkVbg/vmYXqdXZ7DguO5C3Qteu9tNp7Z7Q31TqFWUCrniTI9UJiJCoQ=="
-    },
-    "node_modules/@lumino/signaling": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.4.3.tgz",
-      "integrity": "sha512-6clc8SMcH0tyKXIX31xw6sxjxJl5hj4YRd1DTHTS62cegQ0FkO8JjJeuv+Nc1pgTg6nEAf65aSOHpUdsFHDAvQ==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3"
-      }
-    },
-    "node_modules/@lumino/virtualdom": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.7.3.tgz",
-      "integrity": "sha512-YgQyyo5F7nMfcp5wbpJQyBsztFqAQPO1++sbPCJiF8Mt0Zo5+hN0jWG2tw7IymHdXDNypgnrCiiHQZMUXuzCiA==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3"
-      }
-    },
-    "node_modules/@lumino/widgets": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.13.3.tgz",
-      "integrity": "sha512-rAluFZk0Hc6LeRvsaYjwYz2xPW6qUjZ6JYwm1iEBjFWZpF9pXgMebGTYbswSI5Z38c/uu+gWiofcD0wBq1NwNw==",
-      "dependencies": {
-        "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.11.3",
-        "@lumino/coreutils": "^1.5.3",
-        "@lumino/disposable": "^1.4.3",
-        "@lumino/domutils": "^1.2.3",
-        "@lumino/dragdrop": "^1.6.3",
-        "@lumino/keyboard": "^1.2.3",
-        "@lumino/messaging": "^1.4.3",
-        "@lumino/properties": "^1.2.3",
-        "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.7.3"
-      }
-    },
-    "node_modules/@types/dom4": {
-      "version": "2.0.1",
-      "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.3",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
-    },
-    "node_modules/@types/react": {
-      "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "node_modules/classnames": {
-      "version": "2.2.6",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
-    "node_modules/codemirror": {
-      "version": "5.53.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.53.2.tgz",
-      "integrity": "sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA=="
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/create-react-context": {
-      "version": "0.3.0",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dependencies": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/csstype": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
-      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
-    },
-    "node_modules/deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dependencies": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dependencies": {
-        "object-keys": "^1.0.12"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "3.4.0",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.0.1",
-      "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
-    },
-    "node_modules/dom4": {
-      "version": "2.1.5",
-      "integrity": "sha512-gJbnVGq5zaBUY0lUh0LUEVGYrtN75Ks8ZwpwOYvnVFrKy/qzXK4R/1WuLIFExWj/tBxbRAkTzZUGJHXmqsBNjQ=="
-    },
-    "node_modules/domelementtype": {
-      "version": "1.3.1",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-    },
-    "node_modules/domhandler": {
-      "version": "2.4.2",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "1.7.0",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.1",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
-    },
-    "node_modules/entities": {
-      "version": "1.1.2",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-    },
-    "node_modules/es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dependencies": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-    },
-    "node_modules/free-style": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/free-style/-/free-style-3.1.0.tgz",
-      "integrity": "sha512-vJujYSIyT30iDoaoeigNAxX4yB1RUrh+N2ZMhIElMr3BvCuGXOw7XNJMEEJkDUeamK2Rnb/IKFGKRKlTWIGRWA=="
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "node_modules/gud": {
-      "version": "1.0.0",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-    },
-    "node_modules/htmlparser2": {
-      "version": "3.10.1",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dependencies": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
-    },
-    "node_modules/is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
-    "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-    },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/map-stream": {
-      "version": "0.1.0",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
-    "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
-    },
-    "node_modules/minimatch": {
-      "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "node_modules/moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
-    },
-    "node_modules/node-cleanup": {
-      "version": "2.1.2",
-      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
-      "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/normalize.css": {
-      "version": "8.0.1",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "node_modules/object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
-    },
-    "node_modules/object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "node_modules/path-posix": {
-      "version": "1.0.0",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
-    },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
-    "node_modules/postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      }
-    },
-    "node_modules/postcss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.7.2",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
-    "node_modules/ps-tree": {
-      "version": "1.2.0",
-      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
-      "dev": true,
-      "dependencies": {
-        "event-stream": "=3.3.4"
-      }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "node_modules/querystringify": {
-      "version": "2.1.1",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
-    },
-    "node_modules/react": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.15.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "node_modules/react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "2.9.0",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dependencies": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "node_modules/sanitize-html": {
-      "version": "1.20.1",
-      "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "htmlparser2": "^3.10.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.1",
-        "postcss": "^7.0.5",
-        "srcset": "^1.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "node_modules/split": {
-      "version": "0.3.3",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "dependencies": {
-        "through": "2"
-      }
-    },
-    "node_modules/srcset": {
-      "version": "1.0.0",
-      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
-      "dependencies": {
-        "array-uniq": "^1.0.2",
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "~0.1.1"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-argv": {
-      "version": "0.1.2",
-      "integrity": "sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==",
-      "dev": true
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "node_modules/tsc-watch": {
-      "version": "4.0.0",
-      "integrity": "sha512-I+1cE7WN9YhDknNRAO5NRI7jzeiIZCxUZ0dFEM/Gf+3KTlHasusDEftwezJ+PSFkECSn3RQmf28RdovjTptkRA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^5.1.0",
-        "node-cleanup": "^2.1.2",
-        "ps-tree": "^1.2.0",
-        "string-argv": "^0.1.1",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-    },
-    "node_modules/typed-styles": {
-      "version": "0.0.7",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
-    },
-    "node_modules/typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
-      "dev": true
-    },
-    "node_modules/typestyle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typestyle/-/typestyle-2.1.0.tgz",
-      "integrity": "sha512-6uCYPdG4xWLeEcl9O0GtNFnNGhami+irKiLsXSuvWHC/aTS7wdj49WeikWAKN+xHN3b1hm+9v0svwwgSBhCsNA==",
-      "dependencies": {
-        "csstype": "2.6.9",
-        "free-style": "3.1.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.2.2",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.4.7",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "node_modules/ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    }
-  },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@blueprintjs/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-/fBhPmQ1AJ7ATGzA9YBlnxN8KV7PjNeW9KL+IOWiERUNcF9kuiuKJ88hTs7gSSHNtHmCF+jheD+X0MQq4WYVjA==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.36.0.tgz",
+      "integrity": "sha512-7VUyF+qWelDysajK0Xowlou+iqbGAFfGaM3znpmm7OEEIli5XRWjG9rhNuEk3sP7zbdOJpyqh5PAPDQvm5Sxmg==",
       "requires": {
-        "@blueprintjs/icons": "^3.19.0",
+        "@blueprintjs/icons": "^3.23.0",
         "@types/dom4": "^2.0.1",
         "classnames": "^2.2",
         "dom4": "^2.1.5",
@@ -1389,47 +27,47 @@
         "react-popper": "^1.3.7",
         "react-transition-group": "^2.9.0",
         "resize-observer-polyfill": "^1.5.1",
-        "tslib": "~1.10.0"
+        "tslib": "~1.13.0"
       }
     },
     "@blueprintjs/icons": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.19.0.tgz",
-      "integrity": "sha512-pFgEdSDj8q8ESofuXXSfonsiiqQNJ0u54vr8zxQyKggSwgMyASM/h9MdFVED7jXaj5nsda4or+hWM1ilUeES4Q==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.23.0.tgz",
+      "integrity": "sha512-QOQ3P5bU1FiEwnMBl5Chn433ONSSTIMgC+zZJttyXV0m8R7D1bPBJJqIMuANXtRld/Fj+8IzoQ6jfaVUG16slA==",
       "requires": {
         "classnames": "^2.2",
-        "tslib": "~1.10.0"
+        "tslib": "~1.13.0"
       }
     },
     "@blueprintjs/select": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.13.5.tgz",
-      "integrity": "sha512-GFdLhmD23JvWueLNDBZjE5+Kii1zT/R7vx/Ta5fPv3gdSnUBMyGZMkQAjKWrn7o7xyOE1im5G2A0sdhcfcs3iw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.15.0.tgz",
+      "integrity": "sha512-pRiCVqzrJ+bV/Aac9OouxniD2DJVCVNnkk6KJET7PU9ZxD7Bo/42W9xmTlUCSd7r6FRRarYyKbRRjRXGP7U78g==",
       "requires": {
-        "@blueprintjs/core": "^3.30.0",
+        "@blueprintjs/core": "^3.36.0",
         "classnames": "^2.2",
-        "tslib": "~1.10.0"
+        "tslib": "~1.13.0"
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
-      "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz",
+      "integrity": "sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ=="
     },
     "@jupyterlab/application": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.2.0.tgz",
-      "integrity": "sha512-dayndJ2MahAORRMDrersVvANmOded5GkKKShUAq/8C24bRkKd8zb/U4IpG1Ge93NWVW6ATHjRst6LxkiR+biOA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.2.6.tgz",
+      "integrity": "sha512-pW/Cu+t3CYii52YncrbcRWSfAFTIlsDy8yMxgYqkG6TSsImca3Rix3o69jTu264Ct2UQzEWP4+6u2IqF5wziuw==",
       "requires": {
         "@fortawesome/fontawesome-free": "^5.12.0",
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/docregistry": "^2.2.0",
-        "@jupyterlab/rendermime": "^2.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/statedb": "^2.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
+        "@jupyterlab/apputils": "^2.2.6",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/docregistry": "^2.2.4",
+        "@jupyterlab/rendermime": "^2.2.4",
+        "@jupyterlab/rendermime-interfaces": "^2.2.1",
+        "@jupyterlab/services": "^5.2.5",
+        "@jupyterlab/statedb": "^2.2.5",
+        "@jupyterlab/ui-components": "^2.2.4",
         "@lumino/algorithm": "^1.2.3",
         "@lumino/application": "^1.8.4",
         "@lumino/commands": "^1.10.1",
@@ -1469,14 +107,14 @@
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.2.0.tgz",
-      "integrity": "sha512-BIvvznUEGJ+sjmiyxEKr7OC9O2jDO9mCpoFMV0koPQuQEz/241JltuskM+BeP81CIIyP9yq3Le6qXttsq7dXDQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.2.5.tgz",
+      "integrity": "sha512-ktc5e/30aabx0GwFBiiNOimtBoDx+ZFWkHeKg1ylpHASGgdQt6Km3E+TQARzFWbwkShyc7WFJySK1ES/uimDVg==",
       "requires": {
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/nbformat": "^2.2.5",
+        "@jupyterlab/observables": "^3.2.5",
+        "@jupyterlab/ui-components": "^2.2.4",
         "@lumino/coreutils": "^1.4.2",
         "@lumino/disposable": "^1.3.5",
         "@lumino/dragdrop": "^1.5.1",
@@ -1486,16 +124,16 @@
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.2.0.tgz",
-      "integrity": "sha512-mErh3xhemsUWxgDVxwYxaPmrKruXF0ks/GaRJyfbrTA/m8KnAf4jEbCISXeZTQ31EWAjdmkfUO35TVWvFCQYmg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.2.4.tgz",
+      "integrity": "sha512-arWSgzZxCyLSOGFQvplxnIRdWXJ+VD2skb9OX/Fa/uqknpeyMvGBX5RkaX+edCMjlRfytkWPKlxvMcPgeMVP/Q==",
       "requires": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/statusbar": "^2.2.0",
+        "@jupyterlab/apputils": "^2.2.6",
+        "@jupyterlab/codeeditor": "^2.2.5",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/nbformat": "^2.2.5",
+        "@jupyterlab/observables": "^3.2.5",
+        "@jupyterlab/statusbar": "^2.2.4",
         "@lumino/algorithm": "^1.2.3",
         "@lumino/commands": "^1.10.1",
         "@lumino/coreutils": "^1.4.2",
@@ -1522,19 +160,19 @@
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.2.0.tgz",
-      "integrity": "sha512-jIjZ+YXYoNtTcZzfNBrf/1VNxLTSiMasaOB9jUsgVy6Z3MYuPrRobBp29ovVoTx8s/xe7sEbJr3MHIepJmuZxw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.2.4.tgz",
+      "integrity": "sha512-xmwptfXKr7QkpnNOaLVB/PIWaoZ8JpRCY/cKwQSXq42wkpY7D4iCJyX0iGsPqapJHYOq6g0BnQm195ETTYs/BQ==",
       "requires": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/codemirror": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/rendermime": "^2.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
+        "@jupyterlab/apputils": "^2.2.6",
+        "@jupyterlab/codeeditor": "^2.2.5",
+        "@jupyterlab/codemirror": "^2.2.4",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/observables": "^3.2.5",
+        "@jupyterlab/rendermime": "^2.2.4",
+        "@jupyterlab/rendermime-interfaces": "^2.2.1",
+        "@jupyterlab/services": "^5.2.5",
+        "@jupyterlab/ui-components": "^2.2.4",
         "@lumino/algorithm": "^1.2.3",
         "@lumino/coreutils": "^1.4.2",
         "@lumino/disposable": "^1.3.5",
@@ -1580,17 +218,17 @@
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.2.0.tgz",
-      "integrity": "sha512-wTls25TElx0iAjALKxgWyLW+QGFCAXnyH0XiGkQULrbUauRuoArPQ1hKMcz4KL6XJjydMg6s9cqV9gQ9o3yJ8Q==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.2.4.tgz",
+      "integrity": "sha512-XhBsUQdyidYrNY71+TZUGJSg/mf3kM90lSwIw+DgHSJJz/BXO5bSyKP5XnTSeKYoz40Ko1PCyRyCmKpmI51J6A==",
       "requires": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codemirror": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/nbformat": "^2.2.0",
-        "@jupyterlab/observables": "^3.2.0",
-        "@jupyterlab/rendermime-interfaces": "^2.2.0",
-        "@jupyterlab/services": "^5.2.0",
+        "@jupyterlab/apputils": "^2.2.6",
+        "@jupyterlab/codemirror": "^2.2.4",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/nbformat": "^2.2.5",
+        "@jupyterlab/observables": "^3.2.5",
+        "@jupyterlab/rendermime-interfaces": "^2.2.1",
+        "@jupyterlab/services": "^5.2.5",
         "@lumino/algorithm": "^1.2.3",
         "@lumino/coreutils": "^1.4.2",
         "@lumino/messaging": "^1.3.3",
@@ -1601,9 +239,9 @@
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.2.0.tgz",
-      "integrity": "sha512-2gdYvRzq+IfOKgI751aZY9Gr8of3UeVZ03O2nLyiSlHa6lWhKuzXDPPrKk3NiToOlc2rJSUy+Y9Oj+TONjfvKg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.2.1.tgz",
+      "integrity": "sha512-tjwt3dFfjguV3AeLKhIaCACzaTr2I6F34c4ArJ95WCCRx2DmrRMYFgppLlBo9rKa7BiYeQWZD/lYWvL+GnQZEA==",
       "requires": {
         "@lumino/coreutils": "^1.4.2",
         "@lumino/widgets": "^1.11.1"
@@ -1655,15 +293,15 @@
       }
     },
     "@jupyterlab/statusbar": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.2.0.tgz",
-      "integrity": "sha512-W4gv0kIgqT4nQcctCi8Bb2Wutdcdsy1GMd6fuP/fCRAUqSoDyIGesC1nx/V8+GBEgzBAehSQhFi+4P6Opo6ZyQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.2.4.tgz",
+      "integrity": "sha512-Wyhd5EZYd5Zs4oAsnG1Dt57wE4jUajkGxwr4SSotXXzccmJOLiZsvmNxPuftcZJHqbisG7EweaZXVlKMnb3SsA==",
       "requires": {
-        "@jupyterlab/apputils": "^2.2.0",
-        "@jupyterlab/codeeditor": "^2.2.0",
-        "@jupyterlab/coreutils": "^4.2.0",
-        "@jupyterlab/services": "^5.2.0",
-        "@jupyterlab/ui-components": "^2.2.0",
+        "@jupyterlab/apputils": "^2.2.6",
+        "@jupyterlab/codeeditor": "^2.2.5",
+        "@jupyterlab/coreutils": "^4.2.5",
+        "@jupyterlab/services": "^5.2.5",
+        "@jupyterlab/ui-components": "^2.2.4",
         "@lumino/algorithm": "^1.2.3",
         "@lumino/coreutils": "^1.4.2",
         "@lumino/disposable": "^1.3.5",
@@ -1699,13 +337,13 @@
       "integrity": "sha512-I2BkssbOSLq3rDjgAC3fzf/zAIwkRUnAh60MO0lYcaFdSGyI15w4K3gwZHGIO0p9cKEiNHLXKEODGmOjMLOQ3g=="
     },
     "@lumino/application": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.10.3.tgz",
-      "integrity": "sha512-YYIDmgfYqLfejVYTKSjfIVttyeklSmqepbESHVMj1M1rFLvUlb8DQtS0xFpqVJElpnYAAiIUmGzYMMX5529+rQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.14.0.tgz",
+      "integrity": "sha512-Q1M+75no4x3OvnmspAs81ANoPCXmPcHz9JyOVAQ8jEVsjhsH4anB/oWo72l/Ud9mLVd2nEFvh432K7tPCmkpuQ==",
       "requires": {
-        "@lumino/commands": "^1.11.3",
+        "@lumino/commands": "^1.12.0",
         "@lumino/coreutils": "^1.5.3",
-        "@lumino/widgets": "^1.13.3"
+        "@lumino/widgets": "^1.17.0"
       }
     },
     "@lumino/collections": {
@@ -1717,9 +355,9 @@
       }
     },
     "@lumino/commands": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.11.3.tgz",
-      "integrity": "sha512-0JencVUzJWEaXVDngpLhgOWza6Yql5tq2W2Qsi9U3exEDE3CqXdjehI/Uy4Cj2+aAfZju8iPvyZVlLq2psyKLw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.12.0.tgz",
+      "integrity": "sha512-5TFlhDzZk1X8rCBjhh0HH3j6CcJ03mx2Pd/1rGa7MB5R+3+yYYk+gTlfHRqsxdehNRmiISaHRSrMnW8bynW7ZQ==",
       "requires": {
         "@lumino/algorithm": "^1.3.3",
         "@lumino/coreutils": "^1.5.3",
@@ -1727,7 +365,7 @@
         "@lumino/domutils": "^1.2.3",
         "@lumino/keyboard": "^1.2.3",
         "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.7.3"
+        "@lumino/virtualdom": "^1.8.0"
       }
     },
     "@lumino/coreutils": {
@@ -1750,9 +388,9 @@
       "integrity": "sha512-SEi8WZSy+DWMkL5CfAY78MHbi3x83AVmRFxjs9+A6qsFPde+Hr1I4DNtLsSDmfAWsobHHgBnjyNp2ZkQEq0IEA=="
     },
     "@lumino/dragdrop": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.6.3.tgz",
-      "integrity": "sha512-24SH+CA6N+cNePVKDRfOnphmYwByyRtxi7eH8bA5h4rY1cqyvMTLT6wA0yLFPQJ8c2pE0xZNZKxSc7iy4jhaaQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.7.1.tgz",
+      "integrity": "sha512-IeSSOTmpqBSWz+EVsbGVeHe/KIaHaUsQXZ4BJCEbCKgNGHbqMfUOtlneiKq7rEhZGF4wYs7gWWjNhMVZbUGO9Q==",
       "requires": {
         "@lumino/coreutils": "^1.5.3",
         "@lumino/disposable": "^1.4.3"
@@ -1796,52 +434,168 @@
       }
     },
     "@lumino/virtualdom": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.7.3.tgz",
-      "integrity": "sha512-YgQyyo5F7nMfcp5wbpJQyBsztFqAQPO1++sbPCJiF8Mt0Zo5+hN0jWG2tw7IymHdXDNypgnrCiiHQZMUXuzCiA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.8.0.tgz",
+      "integrity": "sha512-X/1b8b7TxB9tb4+xQiS8oArcA/AK7NBZrsg2dzu/gHa3JC45R8nzQ+0tObD8Nd0gF/e9w9Ps9M62rLfefcbbKw==",
       "requires": {
         "@lumino/algorithm": "^1.3.3"
       }
     },
     "@lumino/widgets": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.13.3.tgz",
-      "integrity": "sha512-rAluFZk0Hc6LeRvsaYjwYz2xPW6qUjZ6JYwm1iEBjFWZpF9pXgMebGTYbswSI5Z38c/uu+gWiofcD0wBq1NwNw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.17.0.tgz",
+      "integrity": "sha512-4MBIaYPTRmpAczXe1s7jg1f1pZ5iOnswLsjex32Debctvc2TnB3gAHm6GLKZ6ptiIGKp0N+WJbQyT+cpmNfSyA==",
       "requires": {
         "@lumino/algorithm": "^1.3.3",
-        "@lumino/commands": "^1.11.3",
+        "@lumino/commands": "^1.12.0",
         "@lumino/coreutils": "^1.5.3",
         "@lumino/disposable": "^1.4.3",
         "@lumino/domutils": "^1.2.3",
-        "@lumino/dragdrop": "^1.6.3",
+        "@lumino/dragdrop": "^1.7.1",
         "@lumino/keyboard": "^1.2.3",
         "@lumino/messaging": "^1.4.3",
         "@lumino/properties": "^1.2.3",
         "@lumino/signaling": "^1.4.3",
-        "@lumino/virtualdom": "^1.7.3"
+        "@lumino/virtualdom": "^1.8.0"
+      }
+    },
+    "@phosphor/algorithm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+      "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
+    },
+    "@phosphor/collections": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
+      "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0"
+      }
+    },
+    "@phosphor/commands": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.7.2.tgz",
+      "integrity": "sha512-iSyBIWMHsus323BVEARBhuVZNnVel8USo+FIPaAxGcq+icTSSe6+NtSxVQSmZblGN6Qm4iw6I6VtiSx0e6YDgQ==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.1",
+        "@phosphor/domutils": "^1.1.4",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/signaling": "^1.3.1"
+      }
+    },
+    "@phosphor/coreutils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
+      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
+    },
+    "@phosphor/disposable": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
+      "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/signaling": "^1.3.1"
+      }
+    },
+    "@phosphor/domutils": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.4.tgz",
+      "integrity": "sha512-ivwq5TWjQpKcHKXO8PrMl+/cKqbgxPClPiCKc1gwbMd+6hnW5VLwNG0WBzJTxCzXK43HxX18oH+tOZ3E04wc3w=="
+    },
+    "@phosphor/dragdrop": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.4.1.tgz",
+      "integrity": "sha512-77paMoubIWk7pdwA2GVFkqba1WP48hTZZvS17N30+KVOeWfSqBL3flPSnW2yC4y6FnOP2PFOCtuPIbQv+pYhCA==",
+      "requires": {
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.1"
+      }
+    },
+    "@phosphor/keyboard": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
+      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
+    },
+    "@phosphor/messaging": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
+      "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/collections": "^1.2.0"
+      }
+    },
+    "@phosphor/properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
+      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
+    },
+    "@phosphor/signaling": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
+      "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0"
+      }
+    },
+    "@phosphor/virtualdom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.2.0.tgz",
+      "integrity": "sha512-L9mKNhK2XtVjzjuHLG2uYuepSz8uPyu6vhF4EgCP0rt0TiLYaZeHwuNu3XeFbul9DMOn49eBpye/tfQVd4Ks+w==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0"
+      }
+    },
+    "@phosphor/widgets": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.9.3.tgz",
+      "integrity": "sha512-61jsxloDrW/+WWQs8wOgsS5waQ/MSsXBuhONt0o6mtdeL93HVz7CYO5krOoot5owammfF6oX1z0sDaUYIYgcPA==",
+      "requires": {
+        "@phosphor/algorithm": "^1.2.0",
+        "@phosphor/commands": "^1.7.2",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.3.1",
+        "@phosphor/domutils": "^1.1.4",
+        "@phosphor/dragdrop": "^1.4.1",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/messaging": "^1.3.0",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.3.1",
+        "@phosphor/virtualdom": "^1.2.0"
       }
     },
     "@types/dom4": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
       "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
     },
     "@types/prop-types": {
       "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
       }
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1850,12 +604,14 @@
       }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
@@ -1863,15 +619,18 @@
     },
     "array-uniq": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -1879,8 +638,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -1890,6 +659,7 @@
     },
     "classnames": {
       "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "codemirror": {
@@ -1899,6 +669,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
         "color-name": "1.1.3"
@@ -1906,15 +677,18 @@
     },
     "color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "create-react-context": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
       "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
       "requires": {
         "gud": "^1.0.0",
@@ -1922,13 +696,14 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "csstype": {
@@ -1959,6 +734,7 @@
     },
     "dom-helpers": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "requires": {
         "@babel/runtime": "^7.1.2"
@@ -1974,26 +750,30 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
         },
         "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
         }
       }
     },
     "dom4": {
-      "version": "2.1.5",
-      "integrity": "sha512-gJbnVGq5zaBUY0lUh0LUEVGYrtN75Ks8ZwpwOYvnVFrKy/qzXK4R/1WuLIFExWj/tBxbRAkTzZUGJHXmqsBNjQ=="
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.6.tgz",
+      "integrity": "sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA=="
     },
     "domelementtype": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
         "domelementtype": "1"
@@ -2001,6 +781,7 @@
     },
     "domutils": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
         "dom-serializer": "0",
@@ -2008,28 +789,30 @@
       }
     },
     "duplexer": {
-      "version": "0.1.1",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
     "entities": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
@@ -2046,10 +829,12 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "event-stream": {
       "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -2079,11 +864,13 @@
     },
     "from": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -2091,6 +878,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -2108,6 +905,7 @@
     },
     "gud": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "has": {
@@ -2120,6 +918,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
@@ -2129,6 +928,7 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "requires": {
         "domelementtype": "^1.3.1",
@@ -2141,6 +941,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2150,17 +951,21 @@
     },
     "inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -2168,9 +973,9 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -2185,15 +990,18 @@
     },
     "isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json5": {
@@ -2206,46 +1014,45 @@
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.escape": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.mergewith": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "loose-envify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "map-stream": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
@@ -2256,6 +1063,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
@@ -2268,12 +1076,13 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "node-cleanup": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
       "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
       "dev": true
     },
@@ -2284,28 +1093,31 @@
     },
     "normalize.css": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
       "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -2314,18 +1126,19 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -2334,15 +1147,24 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-posix": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
       "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "pause-stream": {
       "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -2355,9 +1177,9 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -2366,6 +1188,7 @@
       "dependencies": {
         "supports-color": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -2375,6 +1198,7 @@
     },
     "prop-types": {
       "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
         "loose-envify": "^1.4.0",
@@ -2384,24 +1208,22 @@
     },
     "ps-tree": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
       "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
       "dev": true,
       "requires": {
         "event-stream": "=3.3.4"
       }
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "punycode": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "querystringify": {
-      "version": "2.1.1",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "react": {
       "version": "16.9.0",
@@ -2431,6 +1253,7 @@
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
@@ -2449,6 +1272,7 @@
     },
     "react-transition-group": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
       "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
       "requires": {
         "dom-helpers": "^3.4.0",
@@ -2483,10 +1307,12 @@
     },
     "requires-port": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "rimraf": {
@@ -2505,6 +1331,7 @@
     },
     "sanitize-html": {
       "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
       "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
       "requires": {
         "chalk": "^2.4.1",
@@ -2529,24 +1356,28 @@
       }
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "split": {
       "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
@@ -2555,6 +1386,7 @@
     },
     "srcset": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
         "array-uniq": "^1.0.2",
@@ -2563,52 +1395,57 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1"
       }
     },
+    "string-argv": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.1.2.tgz",
+      "integrity": "sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==",
+      "dev": true
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
       }
     },
-    "string-argv": {
-      "version": "0.1.2",
-      "integrity": "sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==",
-      "dev": true
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
     "strip-ansi": {
-      "version": "4.0.0",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "supports-color": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
@@ -2616,28 +1453,31 @@
     },
     "through": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tsc-watch": {
-      "version": "4.0.0",
-      "integrity": "sha512-I+1cE7WN9YhDknNRAO5NRI7jzeiIZCxUZ0dFEM/Gf+3KTlHasusDEftwezJ+PSFkECSn3RQmf28RdovjTptkRA==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-4.2.9.tgz",
+      "integrity": "sha512-DlTaoDs74+KUpyWr7dCGhuscAUKCz6CiFduBN7R9RbLJSSN1moWdwoCLASE7+zLgGvV5AwXfYDiEMAsPGaO+Vw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.1.0",
+        "cross-spawn": "^7.0.3",
         "node-cleanup": "^2.1.2",
         "ps-tree": "^1.2.0",
         "string-argv": "^0.1.1",
-        "strip-ansi": "^4.0.0"
+        "strip-ansi": "^6.0.0"
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "typed-styles": {
       "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typescript": {
@@ -2656,14 +1496,16 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "url-parse": {
       "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
         "querystringify": "^2.1.1",
@@ -2672,18 +1514,21 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "warning": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
     },
     "which": {
-      "version": "1.3.1",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2691,22 +1536,19 @@
     },
     "wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "A JupyterLab Glue DataBrew extension.",
   "license": "MIT",
-  "author": "cfangzh@amazon.com, zssimjee@amazon.com",
+  "author": "cfangzh@amazon.com, zssimjee@amazon.com, pagtkevi@amazon.com",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
@@ -21,10 +21,12 @@
     "watch:local": "npm run clean && tsc-watch -p tsconfig_local.json --onSuccess 'npm run rename'"
   },
   "dependencies": {
-    "@jupyterlab/application": "^2.0.0",
-    "@jupyterlab/launcher": "^2.2.6",
-    "@lumino/commands": "^1.11.3",
-    "@lumino/widgets": "^1.13.3"
+    "@jupyterlab/application": ">=1.2.0 <3.0.0",
+    "@jupyterlab/launcher": ">=1.2.0 <3.0.0",
+    "@phosphor/commands": "^1.0.0",
+    "@phosphor/widgets": "^1.0.0",
+    "@lumino/commands": "^1.0.0",
+    "@lumino/widgets": "^1.0.0"
   },
   "devDependencies": {
     "rimraf": "^3.0.0",

--- a/src/LeftSideLauncher.ts
+++ b/src/LeftSideLauncher.ts
@@ -1,0 +1,65 @@
+import {
+  Widget as PhosphorWidget,
+} from '@phosphor/widgets';
+
+import {
+  CommandRegistry as PhosphorCommandRegistry,
+} from '@phosphor/commands';
+
+import {
+  Widget as LuminoWidget,
+} from '@lumino/widgets';
+
+import {
+  CommandRegistry as LuminoCommandRegistry,
+} from '@lumino/commands';
+
+import {
+  GLUE_DATABREW_RENDER
+} from './constants';
+
+export class PhosphorLeftSideLauncher extends PhosphorWidget {
+  /**
+   * Command Registry
+   */
+  commands: PhosphorCommandRegistry;
+  handleLaunchButtonClicked() {
+    this.commands.execute(GLUE_DATABREW_RENDER);
+  }
+}
+
+export class LuminoLeftSideLauncher extends LuminoWidget {
+  /**
+   * Command Registry
+   */
+  commands: LuminoCommandRegistry;
+  handleLaunchButtonClicked() {
+    this.commands.execute(GLUE_DATABREW_RENDER);
+  }
+}
+
+export class LeftSideLauncher {
+  static create(version: number, commands: PhosphorCommandRegistry | LuminoCommandRegistry) {
+    const widget = version === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
+    widget.commands = commands;
+
+    const launchButton = document.createElement('div');
+    const header = document.createElement('header');
+    header.className = 'aws_glue_databrew_header';
+    header.textContent = 'AWS Glue DataBrew';
+
+    launchButton.title = 'Welcome to AWS Glue DataBrew';
+    launchButton.id = 'aws_glue_databrew_launch_button';
+    launchButton.textContent = 'Launch AWS Glue DataBrew';
+
+    launchButton.onclick = widget.handleLaunchButtonClicked.bind(widget);
+    
+    widget.node.appendChild(header);
+    widget.node.appendChild(launchButton);
+    widget.id = 'aws_glue_databrew_jupyter_left_side_launcher';
+    widget.title.iconClass = 'jp-databrew-logo jp-SideBar-tabIcon';
+    widget.title.caption = 'AWS Glue DataBrew';
+
+    return widget;
+  }
+}

--- a/src/MainLauncher.ts
+++ b/src/MainLauncher.ts
@@ -1,0 +1,101 @@
+import {
+  Widget as PhosphorWidget,
+} from '@phosphor/widgets';
+
+import {
+  Widget as LuminoWidget,
+} from '@lumino/widgets';
+
+export class PhosphorMainLauncher extends PhosphorWidget {
+  /**
+   * The image element associated with the widget.
+   */
+  consoleRoot: HTMLElement;
+  /**
+   * A path to css assets
+   */
+  cssPath: string;
+}
+
+export class LuminoMainLauncher extends LuminoWidget {
+  /**
+   * The image element associated with the widget.
+   */
+  consoleRoot: HTMLElement;
+  /**
+   * A path to css assets
+   */
+  cssPath: string;
+}
+
+export class MainLauncher {
+  static create(version: number, cssPath: string) {
+    const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
+
+    widget.cssPath = cssPath;
+    widget.id = 'aws_glue_databrew_jupyter';
+    widget.title.label = 'AWS Glue DataBrew';
+    widget.title.closable = true;
+
+    widget.consoleRoot = document.createElement('html');
+    widget.consoleRoot.setAttribute('style', 'height: 100%');
+    widget.node.appendChild(widget.consoleRoot);
+
+    widget.consoleRoot.insertAdjacentHTML('beforeend',
+      `
+        <head>
+          <meta charset="UTF-8">
+          <meta name="awsc-lang" content="en">
+          <meta name="aws-glue-databrew-jupyter" content="true">
+          <title>AWS</title>
+          <link rel="stylesheet" href=` + cssPath + `>
+          <style>
+            .loader {
+              display: inline-block;
+              border: 5px solid #f3f3f3;
+              border-radius: 50%;
+              border-top: 5px solid #3498db;
+              width: 40px;
+              height: 40px;
+              margin-right: 12px;
+              -webkit-animation: spin 2s linear infinite;
+              animation: spin 2s linear infinite;
+            }
+
+            @-webkit-keyframes spin {
+              0% { -webkit-transform: rotate(0deg); }
+              100% { -webkit-transform: rotate(360deg); }
+            }
+
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+
+            .loader-container {
+              font-size: 60px;
+              font-weight: 100;
+              color: #879196;
+              height: 100%;
+              width: 100%;
+              justify-content: center;
+              display: flex;
+              align-items: center;
+            }
+          </style>
+        </head>
+        <body style="height: 100%">
+          <div id="app" style="height: 100%">
+            <div class="loader-container">
+              <div>
+                <div class="loader"></div><span>Launching AWS Glue DataBrew</span>
+              </div>
+            </div>
+          </div>
+        </body>
+    `,
+    );
+
+    return widget;
+  }
+}

--- a/src/aws_glue_databrew_extension.ts
+++ b/src/aws_glue_databrew_extension.ts
@@ -1,5 +1,5 @@
 import {
-  JupyterFrontEnd, JupyterFrontEndPlugin, ILayoutRestorer
+  JupyterFrontEnd, JupyterFrontEndPlugin, ILayoutRestorer,
 } from '@jupyterlab/application';
 
 import {
@@ -7,7 +7,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  ILauncher
+  ILauncher,
 } from '@jupyterlab/launcher';
 
 import {
@@ -15,158 +15,36 @@ import {
 } from '@lumino/widgets';
 
 import {
-  CommandRegistry,
-} from '@lumino/commands';
+  GLUE_DATABREW_RENDER
+} from './constants';
 
 import {
-  LabIcon
-} from '@jupyterlab/ui-components';
+  LeftSideLauncher,
+} from './LeftSideLauncher';
 
-import DATABREW_ICON from '../style/icons/databrew.svg';
+import {
+  MainLauncher,
+} from './MainLauncher';
 
-type GetPathsFunction = () => Promise<string[]>;
-const GLUE_DATABREW_RENDER = 'gluedatabrew:render';
-
-
-/**
- * Left side launcher widget
- */
-export class LeftSideLauncherWidget extends Widget {
-  /**
-   * Command Registry
-   */
-  commands: CommandRegistry;
-
-  constructor(commands: CommandRegistry) {
-    super();
-    this.commands = commands;
-
-    const launchButton = document.createElement('div');
-    const header = document.createElement('header');
-    header.className = 'aws_glue_databrew_header';
-    header.textContent = 'AWS Glue DataBrew';
-
-    launchButton.title = 'Welcome to AWS Glue DataBrew';
-    launchButton.id = 'aws_glue_databrew_launch_button';
-    launchButton.textContent = 'Launch AWS Glue DataBrew';
-    launchButton.onclick = this.handleLaunchButtonClicked.bind(this);
-
-    this.node.appendChild(header);
-    this.node.appendChild(launchButton);
-  }
-
-  handleLaunchButtonClicked() {
-    this.commands.execute(GLUE_DATABREW_RENDER);
-  }
-}
-
-/**
- * A GlueDataBrew console viewer.
- */
-export class GlueDataBrewConsoleWidget extends Widget {
-  /**
-   * The image element associated with the widget.
-   */
-  readonly consoleRoot: HTMLElement;
-
-  /**
-   * A path to css assets
-   */
-  readonly cssPath: string;
-
-  /**
-   * Construct a new glue databrew console widget.
-   */
-  constructor(cssPath: string) {
-    super();
-
-    this.cssPath = cssPath;
-    this.id = 'aws_glue_databrew_jupyter';
-    this.title.label = 'AWS Glue DataBrew';
-    this.title.closable = true;
-
-    this.consoleRoot = document.createElement('html');
-    this.consoleRoot.setAttribute('style', 'height: 100%');
-    this.node.appendChild(this.consoleRoot);
-
-    this.consoleRoot.insertAdjacentHTML('beforeend',
-      `
-        <head>
-          <meta charset="UTF-8">
-          <meta name="awsc-lang" content="en">
-          <meta name="aws-glue-databrew-jupyter" content="true">
-          <title>AWS</title>
-          <link rel="stylesheet" href=` + cssPath + `>
-          <style>
-            .loader {
-              display: inline-block;
-              border: 5px solid #f3f3f3;
-              border-radius: 50%;
-              border-top: 5px solid #3498db;
-              width: 40px;
-              height: 40px;
-              margin-right: 12px;
-              -webkit-animation: spin 2s linear infinite;
-              animation: spin 2s linear infinite;
-            }
-
-            @-webkit-keyframes spin {
-              0% { -webkit-transform: rotate(0deg); }
-              100% { -webkit-transform: rotate(360deg); }
-            }
-
-            @keyframes spin {
-              0% { transform: rotate(0deg); }
-              100% { transform: rotate(360deg); }
-            }
-
-            .loader-container {
-              font-size: 60px;
-              font-weight: 100;
-              color: #879196;
-              height: 100%;
-              width: 100%;
-              justify-content: center;
-              display: flex;
-              align-items: center;
-            }
-          </style>
-        </head>
-        <body style="height: 100%">
-          <div id="app" style="height: 100%">
-            <div class="loader-container">
-              <div>
-                <div class="loader"></div><span>Launching AWS Glue DataBrew</span>
-              </div>
-            </div>
-          </div>
-        </body>
-    `,
-    );
-  }
-}
+const getAppVersion = (app: JupyterFrontEnd) => Number(app.version.split('.')[0]);
 
 /**
  * Initialize the console widget extension
  */
-export const initiateExtension = (getPaths: GetPathsFunction) => {
+export const initiateExtension = (getPaths: () => Promise<string[]>) => {
   const activate = async (app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer, launcher: ILauncher) => {
-
+    const version = getAppVersion(app);
     // Declare a widget variable
     const [jsPath, cssPath] = await getPaths();
-    const consoleWidget: GlueDataBrewConsoleWidget = new GlueDataBrewConsoleWidget(cssPath);
 
-    const databrewIcon = new LabIcon({
-      name: 'gluedatabrew:icon',
-      svgstr: DATABREW_ICON
-    });
+    const consoleWidget = MainLauncher.create(version, cssPath);
 
     app.commands.addCommand(GLUE_DATABREW_RENDER, {
       label: 'Launch AWS Glue DataBrew',
-      icon: databrewIcon,
+      icon: 'jp-databrew-logo',
       execute: () => {
         if (!consoleWidget.isAttached) {
-          app.shell.add(consoleWidget, 'main');
+          app.shell.add(consoleWidget as Widget, 'main');
           const script = document.createElement('script');
 
           script.setAttribute('src', jsPath);
@@ -176,13 +54,10 @@ export const initiateExtension = (getPaths: GetPathsFunction) => {
       },
     });
 
-    const launcherWidget = new LeftSideLauncherWidget(app.commands);
-    launcherWidget.id = 'aws_glue_databrew_jupyter_left_side_launcher';
-    launcherWidget.title.iconClass = 'jp-databrew-logo jp-SideBar-tabIcon';
-    launcherWidget.title.caption = 'AWS Glue DataBrew';
+    const launcherWidget = LeftSideLauncher.create(version, app.commands);
 
-    restorer.add(launcherWidget, launcherWidget.id);
-    app.shell.add(launcherWidget, 'left');
+    restorer.add(launcherWidget as Widget, launcherWidget.id);
+    app.shell.add(launcherWidget as Widget, 'left');
 
     // Add the command to the palette.
     palette.addItem({ command: GLUE_DATABREW_RENDER, category: 'Launcher' });
@@ -210,4 +85,3 @@ export const initiateExtension = (getPaths: GetPathsFunction) => {
 
   return extension;
 };
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const GLUE_DATABREW_RENDER = 'gluedatabrew:render';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
   "include": [
     "src/index.ts",
     "src/aws_glue_databrew_extension.ts",
+    "src/MainLauncher.ts",
+    "src/LeftSideLauncher.ts",
+    "src/constants.ts",
     "src/svg_icons.d.ts"
   ]
 }

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1795 +1,1677 @@
 {
   "program": {
     "fileInfos": {
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es5.d.ts": {
-        "version": "c9a1f03d6ba0fe3c871eb0dd81622e78fbb61ade70878b34d48a341a690c59e9",
-        "signature": "c9a1f03d6ba0fe3c871eb0dd81622e78fbb61ade70878b34d48a341a690c59e9",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "fc43680ad3a1a4ec8c7b8d908af1ec9ddff87845346de5f02c735c9171fa98ea",
+        "signature": "fc43680ad3a1a4ec8c7b8d908af1ec9ddff87845346de5f02c735c9171fa98ea"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.d.ts": {
-        "version": "dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6",
-        "signature": "dc47c4fa66b9b9890cf076304de2a9c5201e94b740cffdf09f87296d877d71f6",
-        "affectsGlobalScope": false
+      "./node_modules/typescript/lib/lib.es2015.d.ts": {
+        "version": "7994d44005046d1413ea31d046577cdda33b8b2470f30281fd9c8b3c99fe2d96",
+        "signature": "7994d44005046d1413ea31d046577cdda33b8b2470f30281fd9c8b3c99fe2d96"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2016.d.ts": {
-        "version": "7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467",
-        "signature": "7a387c58583dfca701b6c85e0adaf43fb17d590fb16d5b2dc0a2fbd89f35c467",
-        "affectsGlobalScope": false
+      "./node_modules/typescript/lib/lib.es2016.d.ts": {
+        "version": "5f217838d25704474d9ef93774f04164889169ca31475fe423a9de6758f058d1",
+        "signature": "5f217838d25704474d9ef93774f04164889169ca31475fe423a9de6758f058d1"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.d.ts": {
-        "version": "8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9",
-        "signature": "8a12173c586e95f4433e0c6dc446bc88346be73ffe9ca6eec7aa63c8f3dca7f9",
-        "affectsGlobalScope": false
+      "./node_modules/typescript/lib/lib.es2017.d.ts": {
+        "version": "459097c7bdd88fc5731367e56591e4f465f2c9de81a35427a7bd473165c34743",
+        "signature": "459097c7bdd88fc5731367e56591e4f465f2c9de81a35427a7bd473165c34743"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.dom.d.ts": {
-        "version": "38130cdd16bd2318b9362f9d60dd9670f7e38708bb6131cf11fc78a41b2c34a0",
-        "signature": "38130cdd16bd2318b9362f9d60dd9670f7e38708bb6131cf11fc78a41b2c34a0",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "d93de5e8a7275cb9d47481410e13b3b1debb997e216490954b5d106e37e086de",
+        "signature": "d93de5e8a7275cb9d47481410e13b3b1debb997e216490954b5d106e37e086de"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.dom.iterable.d.ts": {
-        "version": "fb0c09b697dc42afa84d1587e3c994a2f554d2a45635e4f0618768d16a86b69a",
-        "signature": "fb0c09b697dc42afa84d1587e3c994a2f554d2a45635e4f0618768d16a86b69a",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.dom.iterable.d.ts": {
+        "version": "8329c3401aa8708426c7760f14219170f69a2cb77e4519758cec6f5027270faf",
+        "signature": "8329c3401aa8708426c7760f14219170f69a2cb77e4519758cec6f5027270faf"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
-        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
-        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "fe4e59403e34c7ff747abe4ff6abbc7718229556d7c1a5b93473fb53156c913b",
+        "signature": "fe4e59403e34c7ff747abe4ff6abbc7718229556d7c1a5b93473fb53156c913b"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.scripthost.d.ts": {
-        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
-        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "b9faa17292f17d2ad75e34fac77dd63a6403af1dba02d39cd0cbb9ffdf3de8b9",
+        "signature": "b9faa17292f17d2ad75e34fac77dd63a6403af1dba02d39cd0cbb9ffdf3de8b9"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.core.d.ts": {
-        "version": "46ee15e9fefa913333b61eaf6b18885900b139867d89832a515059b62cf16a17",
-        "signature": "46ee15e9fefa913333b61eaf6b18885900b139867d89832a515059b62cf16a17",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.core.d.ts": {
+        "version": "734ddc145e147fbcd55f07d034f50ccff1086f5a880107665ec326fb368876f6",
+        "signature": "734ddc145e147fbcd55f07d034f50ccff1086f5a880107665ec326fb368876f6"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.collection.d.ts": {
-        "version": "43fb1d932e4966a39a41b464a12a81899d9ae5f2c829063f5571b6b87e6d2f9c",
-        "signature": "43fb1d932e4966a39a41b464a12a81899d9ae5f2c829063f5571b6b87e6d2f9c",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.collection.d.ts": {
+        "version": "4a0862a21f4700de873db3b916f70e41570e2f558da77d2087c9490f5a0615d8",
+        "signature": "4a0862a21f4700de873db3b916f70e41570e2f558da77d2087c9490f5a0615d8"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.generator.d.ts": {
-        "version": "cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a",
-        "signature": "cdccba9a388c2ee3fd6ad4018c640a471a6c060e96f1232062223063b0a5ac6a",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.generator.d.ts": {
+        "version": "765e0e9c9d74cf4d031ca8b0bdb269a853e7d81eda6354c8510218d03db12122",
+        "signature": "765e0e9c9d74cf4d031ca8b0bdb269a853e7d81eda6354c8510218d03db12122"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.iterable.d.ts": {
-        "version": "42f5e41e5893da663dbf0394268f54f1da4b43dc0ddd2ea4bf471fe5361d6faf",
-        "signature": "42f5e41e5893da663dbf0394268f54f1da4b43dc0ddd2ea4bf471fe5361d6faf",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.iterable.d.ts": {
+        "version": "285958e7699f1babd76d595830207f18d719662a0c30fac7baca7df7162a9210",
+        "signature": "285958e7699f1babd76d595830207f18d719662a0c30fac7baca7df7162a9210"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.promise.d.ts": {
-        "version": "0b7a905675e6cb4211c128f0a3aa47d414b275180a299a9aad5d3ec298abbfc4",
-        "signature": "0b7a905675e6cb4211c128f0a3aa47d414b275180a299a9aad5d3ec298abbfc4",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.promise.d.ts": {
+        "version": "d4deaafbb18680e3143e8b471acd650ed6f72a408a33137f0a0dd104fbe7f8ca",
+        "signature": "d4deaafbb18680e3143e8b471acd650ed6f72a408a33137f0a0dd104fbe7f8ca"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.proxy.d.ts": {
-        "version": "dfff68b3c34338f6b307a25d4566de15eed7973b0dc5d69f9fde2bcac1c25315",
-        "signature": "dfff68b3c34338f6b307a25d4566de15eed7973b0dc5d69f9fde2bcac1c25315",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.proxy.d.ts": {
+        "version": "5e72f949a89717db444e3bd9433468890068bb21a5638d8ab15a1359e05e54fe",
+        "signature": "5e72f949a89717db444e3bd9433468890068bb21a5638d8ab15a1359e05e54fe"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.reflect.d.ts": {
-        "version": "cb609802a8698aa28b9c56331d4b53f590ca3c1c3a255350304ae3d06017779d",
-        "signature": "cb609802a8698aa28b9c56331d4b53f590ca3c1c3a255350304ae3d06017779d",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.reflect.d.ts": {
+        "version": "f5b242136ae9bfb1cc99a5971cccc44e99947ae6b5ef6fd8aa54b5ade553b976",
+        "signature": "f5b242136ae9bfb1cc99a5971cccc44e99947ae6b5ef6fd8aa54b5ade553b976"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.symbol.d.ts": {
-        "version": "3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93",
-        "signature": "3013574108c36fd3aaca79764002b3717da09725a36a6fc02eac386593110f93",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.symbol.d.ts": {
+        "version": "9ae2860252d6b5f16e2026d8a2c2069db7b2a3295e98b6031d01337b96437230",
+        "signature": "9ae2860252d6b5f16e2026d8a2c2069db7b2a3295e98b6031d01337b96437230"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts": {
-        "version": "4670208dd7da9d6c774ab1b75c1527a810388c7989c4905de6aaea8561cb9dce",
-        "signature": "4670208dd7da9d6c774ab1b75c1527a810388c7989c4905de6aaea8561cb9dce",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts": {
+        "version": "3e0a459888f32b42138d5a39f706ff2d55d500ab1031e0988b5568b0f67c2303",
+        "signature": "3e0a459888f32b42138d5a39f706ff2d55d500ab1031e0988b5568b0f67c2303"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2016.array.include.d.ts": {
-        "version": "3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006",
-        "signature": "3be5a1453daa63e031d266bf342f3943603873d890ab8b9ada95e22389389006",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2016.array.include.d.ts": {
+        "version": "3f96f1e570aedbd97bf818c246727151e873125d0512e4ae904330286c721bc0",
+        "signature": "3f96f1e570aedbd97bf818c246727151e873125d0512e4ae904330286c721bc0"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.object.d.ts": {
-        "version": "17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a",
-        "signature": "17bb1fc99591b00515502d264fa55dc8370c45c5298f4a5c2083557dccba5a2a",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2017.object.d.ts": {
+        "version": "c2d60b2e558d44384e4704b00e6b3d154334721a911f094d3133c35f0917b408",
+        "signature": "c2d60b2e558d44384e4704b00e6b3d154334721a911f094d3133c35f0917b408"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts": {
-        "version": "b5e4c2d67aa844ed503b29cd4ca2ede1a229ac7fe874613b2c996fa9c581a25f",
-        "signature": "b5e4c2d67aa844ed503b29cd4ca2ede1a229ac7fe874613b2c996fa9c581a25f",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts": {
+        "version": "b8667586a618c5cf64523d4e500ae39e781428abfb28f3de441fc66b56144b6f",
+        "signature": "b8667586a618c5cf64523d4e500ae39e781428abfb28f3de441fc66b56144b6f"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.string.d.ts": {
-        "version": "6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577",
-        "signature": "6a6b173e739a6a99629a8594bfb294cc7329bfb7b227f12e1f7c11bc163b8577",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2017.string.d.ts": {
+        "version": "21df2e0059f14dcb4c3a0e125859f6b6ff01332ee24b0065a741d121250bc71c",
+        "signature": "21df2e0059f14dcb4c3a0e125859f6b6ff01332ee24b0065a741d121250bc71c"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.intl.d.ts": {
-        "version": "12a310447c5d23c7d0d5ca2af606e3bd08afda69100166730ab92c62999ebb9d",
-        "signature": "12a310447c5d23c7d0d5ca2af606e3bd08afda69100166730ab92c62999ebb9d",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2017.intl.d.ts": {
+        "version": "c1759cb171c7619af0d2234f2f8fb2a871ee88e956e2ed91bb61778e41f272c6",
+        "signature": "c1759cb171c7619af0d2234f2f8fb2a871ee88e956e2ed91bb61778e41f272c6"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts": {
-        "version": "b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e",
-        "signature": "b0124885ef82641903d232172577f2ceb5d3e60aed4da1153bab4221e1f6dd4e",
-        "affectsGlobalScope": true
+      "./node_modules/typescript/lib/lib.es2017.typedarrays.d.ts": {
+        "version": "28569d59e07d4378cb3d54979c4c60f9f06305c9bb6999ffe6cab758957adc46",
+        "signature": "28569d59e07d4378cb3d54979c4c60f9f06305c9bb6999ffe6cab758957adc46"
       },
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.full.d.ts": {
-        "version": "d2f31f19e1ba6ed59be9259d660a239d9a3fcbbc8e038c6b2009bde34b175fed",
-        "signature": "d2f31f19e1ba6ed59be9259d660a239d9a3fcbbc8e038c6b2009bde34b175fed",
-        "affectsGlobalScope": false
+      "./node_modules/typescript/lib/lib.es2017.full.d.ts": {
+        "version": "873c09f1c309389742d98b7b67419a8e0a5fa6f10ce59fd5149ecd31a2818594",
+        "signature": "873c09f1c309389742d98b7b67419a8e0a5fa6f10ce59fd5149ecd31a2818594"
       },
       "./node_modules/@lumino/coreutils/types/json.d.ts": {
         "version": "44a4b5ef53f2ff94bfcfa223e3fc3ad35f32bef57337e050513dd7c729a0cb63",
-        "signature": "44a4b5ef53f2ff94bfcfa223e3fc3ad35f32bef57337e050513dd7c729a0cb63",
-        "affectsGlobalScope": false
+        "signature": "44a4b5ef53f2ff94bfcfa223e3fc3ad35f32bef57337e050513dd7c729a0cb63"
       },
       "./node_modules/@lumino/coreutils/types/mime.d.ts": {
         "version": "47dbb9212d0f309e56914de06038a91ad4f0ce9e28a200ebe7c8268bada8fede",
-        "signature": "47dbb9212d0f309e56914de06038a91ad4f0ce9e28a200ebe7c8268bada8fede",
-        "affectsGlobalScope": false
+        "signature": "47dbb9212d0f309e56914de06038a91ad4f0ce9e28a200ebe7c8268bada8fede"
       },
       "./node_modules/@lumino/coreutils/types/promise.d.ts": {
         "version": "a57ee34edf8791c8c4395ada1fb459df7aad714838555ab306729b66db795840",
-        "signature": "a57ee34edf8791c8c4395ada1fb459df7aad714838555ab306729b66db795840",
-        "affectsGlobalScope": false
+        "signature": "a57ee34edf8791c8c4395ada1fb459df7aad714838555ab306729b66db795840"
       },
       "./node_modules/@lumino/coreutils/types/random.d.ts": {
         "version": "615e4d11ecad76f74ca65a175f3c3b3f7c82be6abe41436c61505d6bf700fab5",
-        "signature": "615e4d11ecad76f74ca65a175f3c3b3f7c82be6abe41436c61505d6bf700fab5",
-        "affectsGlobalScope": false
+        "signature": "615e4d11ecad76f74ca65a175f3c3b3f7c82be6abe41436c61505d6bf700fab5"
       },
       "./node_modules/@lumino/coreutils/types/token.d.ts": {
         "version": "facc62a0c8748f37d6c85d3e5a6eb4cd1d40a899d4ee2c360c9ec4756513931c",
-        "signature": "facc62a0c8748f37d6c85d3e5a6eb4cd1d40a899d4ee2c360c9ec4756513931c",
-        "affectsGlobalScope": false
+        "signature": "facc62a0c8748f37d6c85d3e5a6eb4cd1d40a899d4ee2c360c9ec4756513931c"
       },
       "./node_modules/@lumino/coreutils/types/uuid.d.ts": {
         "version": "912f540154a35a5c589e394710cf2472e7fd005893f3aed8353e3ff1c6cc7509",
-        "signature": "912f540154a35a5c589e394710cf2472e7fd005893f3aed8353e3ff1c6cc7509",
-        "affectsGlobalScope": false
+        "signature": "912f540154a35a5c589e394710cf2472e7fd005893f3aed8353e3ff1c6cc7509"
       },
       "./node_modules/@lumino/coreutils/types/index.d.ts": {
         "version": "14291b5cf9f3318a8aec9e856b6563cc1aaf8b0fc4b7a87117f29ecac8e7b803",
-        "signature": "14291b5cf9f3318a8aec9e856b6563cc1aaf8b0fc4b7a87117f29ecac8e7b803",
-        "affectsGlobalScope": false
+        "signature": "14291b5cf9f3318a8aec9e856b6563cc1aaf8b0fc4b7a87117f29ecac8e7b803"
       },
       "./node_modules/@lumino/algorithm/types/array.d.ts": {
         "version": "df52f40fae2bd287b9fb52f0d4cd6978891f5b9e12c8bc4b51f5aeb20673db24",
-        "signature": "df52f40fae2bd287b9fb52f0d4cd6978891f5b9e12c8bc4b51f5aeb20673db24",
-        "affectsGlobalScope": false
+        "signature": "df52f40fae2bd287b9fb52f0d4cd6978891f5b9e12c8bc4b51f5aeb20673db24"
       },
       "./node_modules/@lumino/algorithm/types/iter.d.ts": {
         "version": "95a373d620cf8adb5baa4d4f18c0880d9279761d742075693b64dcfe25d93249",
-        "signature": "95a373d620cf8adb5baa4d4f18c0880d9279761d742075693b64dcfe25d93249",
-        "affectsGlobalScope": false
+        "signature": "95a373d620cf8adb5baa4d4f18c0880d9279761d742075693b64dcfe25d93249"
       },
       "./node_modules/@lumino/algorithm/types/chain.d.ts": {
         "version": "59c71ace3907b7558202ab9fb0fc29d0f000455e6addb8891476ea6f29704fb0",
-        "signature": "59c71ace3907b7558202ab9fb0fc29d0f000455e6addb8891476ea6f29704fb0",
-        "affectsGlobalScope": false
+        "signature": "59c71ace3907b7558202ab9fb0fc29d0f000455e6addb8891476ea6f29704fb0"
       },
       "./node_modules/@lumino/algorithm/types/empty.d.ts": {
         "version": "71d30de4d06e783009da711978077e046ec2a2340cc3307d0d18e832edffc52f",
-        "signature": "71d30de4d06e783009da711978077e046ec2a2340cc3307d0d18e832edffc52f",
-        "affectsGlobalScope": false
+        "signature": "71d30de4d06e783009da711978077e046ec2a2340cc3307d0d18e832edffc52f"
       },
       "./node_modules/@lumino/algorithm/types/enumerate.d.ts": {
         "version": "49fa72b3dd09f2d8cfa8538f3aba53644e90a99866c486a1e535f6e45a809019",
-        "signature": "49fa72b3dd09f2d8cfa8538f3aba53644e90a99866c486a1e535f6e45a809019",
-        "affectsGlobalScope": false
+        "signature": "49fa72b3dd09f2d8cfa8538f3aba53644e90a99866c486a1e535f6e45a809019"
       },
       "./node_modules/@lumino/algorithm/types/filter.d.ts": {
         "version": "4bd953ab46129d1a06fc848cc1e04f69d003cba1010839ae5f11d9a8ecc1b45c",
-        "signature": "4bd953ab46129d1a06fc848cc1e04f69d003cba1010839ae5f11d9a8ecc1b45c",
-        "affectsGlobalScope": false
+        "signature": "4bd953ab46129d1a06fc848cc1e04f69d003cba1010839ae5f11d9a8ecc1b45c"
       },
       "./node_modules/@lumino/algorithm/types/find.d.ts": {
         "version": "985be8579445c37fccc690db36529d9197abac484b76e2374845eda82fc134be",
-        "signature": "985be8579445c37fccc690db36529d9197abac484b76e2374845eda82fc134be",
-        "affectsGlobalScope": false
+        "signature": "985be8579445c37fccc690db36529d9197abac484b76e2374845eda82fc134be"
       },
       "./node_modules/@lumino/algorithm/types/map.d.ts": {
         "version": "778e780516d0cfa36e160dcdbc2cc64193fb13853c4019bafeb2adc39d4b6f95",
-        "signature": "778e780516d0cfa36e160dcdbc2cc64193fb13853c4019bafeb2adc39d4b6f95",
-        "affectsGlobalScope": false
+        "signature": "778e780516d0cfa36e160dcdbc2cc64193fb13853c4019bafeb2adc39d4b6f95"
       },
       "./node_modules/@lumino/algorithm/types/range.d.ts": {
         "version": "61821a4dfe8525bb4082648600ecd1f945698fb65a0bbf4fa2b6e160751fe5e1",
-        "signature": "61821a4dfe8525bb4082648600ecd1f945698fb65a0bbf4fa2b6e160751fe5e1",
-        "affectsGlobalScope": false
+        "signature": "61821a4dfe8525bb4082648600ecd1f945698fb65a0bbf4fa2b6e160751fe5e1"
       },
       "./node_modules/@lumino/algorithm/types/reduce.d.ts": {
         "version": "6f2192fe22e5aed3e61ae7891921feb8601bfa101161c7b522965d709210cc41",
-        "signature": "6f2192fe22e5aed3e61ae7891921feb8601bfa101161c7b522965d709210cc41",
-        "affectsGlobalScope": false
+        "signature": "6f2192fe22e5aed3e61ae7891921feb8601bfa101161c7b522965d709210cc41"
       },
       "./node_modules/@lumino/algorithm/types/repeat.d.ts": {
         "version": "39effd6ab75c733dd48cbe43a91658cec9cf86db5a961d3b091d8194b7e7b573",
-        "signature": "39effd6ab75c733dd48cbe43a91658cec9cf86db5a961d3b091d8194b7e7b573",
-        "affectsGlobalScope": false
+        "signature": "39effd6ab75c733dd48cbe43a91658cec9cf86db5a961d3b091d8194b7e7b573"
       },
       "./node_modules/@lumino/algorithm/types/retro.d.ts": {
         "version": "431207ccbae58b4046cba4a5956beeea69a151defc993bcba16b357cbc8871e7",
-        "signature": "431207ccbae58b4046cba4a5956beeea69a151defc993bcba16b357cbc8871e7",
-        "affectsGlobalScope": false
+        "signature": "431207ccbae58b4046cba4a5956beeea69a151defc993bcba16b357cbc8871e7"
       },
       "./node_modules/@lumino/algorithm/types/sort.d.ts": {
         "version": "2053f012d9d8edaeb4b66bb65120888dd342be84316cc7b85e78cae9ceade349",
-        "signature": "2053f012d9d8edaeb4b66bb65120888dd342be84316cc7b85e78cae9ceade349",
-        "affectsGlobalScope": false
+        "signature": "2053f012d9d8edaeb4b66bb65120888dd342be84316cc7b85e78cae9ceade349"
       },
       "./node_modules/@lumino/algorithm/types/stride.d.ts": {
         "version": "bcfae0d75f0dd13b0d0bd6bb6a1a527076f23d48335a1530211d4926556edf4d",
-        "signature": "bcfae0d75f0dd13b0d0bd6bb6a1a527076f23d48335a1530211d4926556edf4d",
-        "affectsGlobalScope": false
+        "signature": "bcfae0d75f0dd13b0d0bd6bb6a1a527076f23d48335a1530211d4926556edf4d"
       },
       "./node_modules/@lumino/algorithm/types/string.d.ts": {
         "version": "b8186710d384b0b58f9ac2e8e9e4a8cf6385718fd47f12adfca9e163def1fa5e",
-        "signature": "b8186710d384b0b58f9ac2e8e9e4a8cf6385718fd47f12adfca9e163def1fa5e",
-        "affectsGlobalScope": false
+        "signature": "b8186710d384b0b58f9ac2e8e9e4a8cf6385718fd47f12adfca9e163def1fa5e"
       },
       "./node_modules/@lumino/algorithm/types/take.d.ts": {
         "version": "2e55931399ada20784a0903627d3e7cac14e6849ef7e589f32907ed733160af0",
-        "signature": "2e55931399ada20784a0903627d3e7cac14e6849ef7e589f32907ed733160af0",
-        "affectsGlobalScope": false
+        "signature": "2e55931399ada20784a0903627d3e7cac14e6849ef7e589f32907ed733160af0"
       },
       "./node_modules/@lumino/algorithm/types/zip.d.ts": {
         "version": "425744ecce376e0c201eb15a24df23c20b9f9222c25501a64147191255f1a5bb",
-        "signature": "425744ecce376e0c201eb15a24df23c20b9f9222c25501a64147191255f1a5bb",
-        "affectsGlobalScope": false
+        "signature": "425744ecce376e0c201eb15a24df23c20b9f9222c25501a64147191255f1a5bb"
       },
       "./node_modules/@lumino/algorithm/types/index.d.ts": {
         "version": "d9700500170f5138bbb3b59ede0d2303486b24826a19dd242eaaa667a3735b63",
-        "signature": "d9700500170f5138bbb3b59ede0d2303486b24826a19dd242eaaa667a3735b63",
-        "affectsGlobalScope": false
+        "signature": "d9700500170f5138bbb3b59ede0d2303486b24826a19dd242eaaa667a3735b63"
       },
       "./node_modules/@lumino/signaling/types/index.d.ts": {
         "version": "11e5e4c5983c5150410112a156503aa02b29fed56100314eb3a77334a5e2ec6c",
-        "signature": "11e5e4c5983c5150410112a156503aa02b29fed56100314eb3a77334a5e2ec6c",
-        "affectsGlobalScope": false
+        "signature": "11e5e4c5983c5150410112a156503aa02b29fed56100314eb3a77334a5e2ec6c"
       },
       "./node_modules/@lumino/disposable/types/index.d.ts": {
         "version": "97056de69d4d1897fa4d77b047fdfd64771269238bd627b7ff5af6cd2bc8edf1",
-        "signature": "97056de69d4d1897fa4d77b047fdfd64771269238bd627b7ff5af6cd2bc8edf1",
-        "affectsGlobalScope": false
+        "signature": "97056de69d4d1897fa4d77b047fdfd64771269238bd627b7ff5af6cd2bc8edf1"
       },
       "./node_modules/@lumino/virtualdom/types/index.d.ts": {
-        "version": "44a8be96842899b8250784c2f87eea9f7e084931a4478baf6cf4109560b0533a",
-        "signature": "44a8be96842899b8250784c2f87eea9f7e084931a4478baf6cf4109560b0533a",
-        "affectsGlobalScope": false
+        "version": "bafd6e4b18662d1f49009d3cbc1c0a6a2358ae8b5487dc27d32e778546ca12f5",
+        "signature": "bafd6e4b18662d1f49009d3cbc1c0a6a2358ae8b5487dc27d32e778546ca12f5"
       },
       "./node_modules/@lumino/commands/types/index.d.ts": {
-        "version": "7506970552ee6175b21032f115affb5f91bf41fc24f7d8310e1a21d49b636e49",
-        "signature": "7506970552ee6175b21032f115affb5f91bf41fc24f7d8310e1a21d49b636e49",
-        "affectsGlobalScope": false
+        "version": "4a45257708f8412a2a999e2915fbad70abdd12344e56934a3b52b2efc609b1e9",
+        "signature": "4a45257708f8412a2a999e2915fbad70abdd12344e56934a3b52b2efc609b1e9"
       },
       "./node_modules/@jupyterlab/services/lib/config/index.d.ts": {
         "version": "41bd5decb99be607b760e0fcec9bccb318b0db4e32fa4771d07fdeffca120552",
-        "signature": "41bd5decb99be607b760e0fcec9bccb318b0db4e32fa4771d07fdeffca120552",
-        "affectsGlobalScope": false
+        "signature": "41bd5decb99be607b760e0fcec9bccb318b0db4e32fa4771d07fdeffca120552"
       },
       "./node_modules/@lumino/messaging/types/index.d.ts": {
         "version": "cac40d24651330bd29ebcf835dc9014a8d9ce02219503fb1dd880ffd27d71b3b",
-        "signature": "cac40d24651330bd29ebcf835dc9014a8d9ce02219503fb1dd880ffd27d71b3b",
-        "affectsGlobalScope": false
+        "signature": "cac40d24651330bd29ebcf835dc9014a8d9ce02219503fb1dd880ffd27d71b3b"
       },
       "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts": {
         "version": "661a64c322166f6efa02715c10a2ae836ca59dab3ce7c09370b11dd99e624a25",
-        "signature": "661a64c322166f6efa02715c10a2ae836ca59dab3ce7c09370b11dd99e624a25",
-        "affectsGlobalScope": false
+        "signature": "661a64c322166f6efa02715c10a2ae836ca59dab3ce7c09370b11dd99e624a25"
       },
       "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts": {
         "version": "e330139099ebcf6830ae396ff59e59e09ae0f6b56ebdc9205609e66843d7e3ef",
-        "signature": "e330139099ebcf6830ae396ff59e59e09ae0f6b56ebdc9205609e66843d7e3ef",
-        "affectsGlobalScope": false
+        "signature": "e330139099ebcf6830ae396ff59e59e09ae0f6b56ebdc9205609e66843d7e3ef"
       },
       "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts": {
         "version": "f3c6769aeebc6890c190aa33831461a7d7d0d59ae1474555594dc480af6a4a5b",
-        "signature": "f3c6769aeebc6890c190aa33831461a7d7d0d59ae1474555594dc480af6a4a5b",
-        "affectsGlobalScope": false
+        "signature": "f3c6769aeebc6890c190aa33831461a7d7d0d59ae1474555594dc480af6a4a5b"
       },
       "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts": {
         "version": "abe5fc339dc9bc6cfdce825ae8e80171fb62c93506796aa86743d4c46f86cfa6",
-        "signature": "abe5fc339dc9bc6cfdce825ae8e80171fb62c93506796aa86743d4c46f86cfa6",
-        "affectsGlobalScope": false
+        "signature": "abe5fc339dc9bc6cfdce825ae8e80171fb62c93506796aa86743d4c46f86cfa6"
       },
       "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts": {
         "version": "17b1e1fc5d431f6380ab9ae528d4c3fa648bcfbe5cd49e9061c7779fc3095f7f",
-        "signature": "17b1e1fc5d431f6380ab9ae528d4c3fa648bcfbe5cd49e9061c7779fc3095f7f",
-        "affectsGlobalScope": false
+        "signature": "17b1e1fc5d431f6380ab9ae528d4c3fa648bcfbe5cd49e9061c7779fc3095f7f"
       },
       "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts": {
         "version": "7289477bfdc020fa43a85016fbe14b0d9f6e0f90511e274b16e6c74fa4d0f102",
-        "signature": "7289477bfdc020fa43a85016fbe14b0d9f6e0f90511e274b16e6c74fa4d0f102",
-        "affectsGlobalScope": false
+        "signature": "7289477bfdc020fa43a85016fbe14b0d9f6e0f90511e274b16e6c74fa4d0f102"
       },
       "./node_modules/@jupyterlab/observables/lib/index.d.ts": {
         "version": "14272cf5e560df638409e768e655862b5b9524ecd34a3f6a6ea5f7854af76bb0",
-        "signature": "14272cf5e560df638409e768e655862b5b9524ecd34a3f6a6ea5f7854af76bb0",
-        "affectsGlobalScope": false
+        "signature": "14272cf5e560df638409e768e655862b5b9524ecd34a3f6a6ea5f7854af76bb0"
       },
       "./node_modules/@jupyterlab/services/lib/contents/index.d.ts": {
         "version": "f9edb48866ff05ad346eec5339163d7a2a9c8c684f58607f4abfdc59e557ba68",
-        "signature": "f9edb48866ff05ad346eec5339163d7a2a9c8c684f58607f4abfdc59e557ba68",
-        "affectsGlobalScope": false
+        "signature": "f9edb48866ff05ad346eec5339163d7a2a9c8c684f58607f4abfdc59e557ba68"
       },
       "./node_modules/@jupyterlab/nbformat/lib/index.d.ts": {
         "version": "09f752f2778fe814e66febd490692755553cd392c19a3a0fdb02ab39f34169cc",
-        "signature": "09f752f2778fe814e66febd490692755553cd392c19a3a0fdb02ab39f34169cc",
-        "affectsGlobalScope": false
+        "signature": "09f752f2778fe814e66febd490692755553cd392c19a3a0fdb02ab39f34169cc"
       },
       "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts": {
         "version": "cc70374948e21539d27e6f52d7683e23f11be91796447bd040958bdd9def0691",
-        "signature": "cc70374948e21539d27e6f52d7683e23f11be91796447bd040958bdd9def0691",
-        "affectsGlobalScope": false
+        "signature": "cc70374948e21539d27e6f52d7683e23f11be91796447bd040958bdd9def0691"
       },
       "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts": {
         "version": "bf0c827efe9423b447253f11b42aaec17cdc4a2e5870e5dfc9d23e50822b6b20",
-        "signature": "bf0c827efe9423b447253f11b42aaec17cdc4a2e5870e5dfc9d23e50822b6b20",
-        "affectsGlobalScope": false
+        "signature": "bf0c827efe9423b447253f11b42aaec17cdc4a2e5870e5dfc9d23e50822b6b20"
       },
       "./node_modules/@jupyterlab/services/lib/basemanager.d.ts": {
         "version": "ed186aff8f5899e1c5bc14ccff9c892a6e701d6aee339e38e10ae76d8d0f60fe",
-        "signature": "ed186aff8f5899e1c5bc14ccff9c892a6e701d6aee339e38e10ae76d8d0f60fe",
-        "affectsGlobalScope": false
+        "signature": "ed186aff8f5899e1c5bc14ccff9c892a6e701d6aee339e38e10ae76d8d0f60fe"
       },
       "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts": {
         "version": "1e516b8aace99b3cfd896b1d52f51c8d7186fb721718007f2fd632d65caaa204",
-        "signature": "1e516b8aace99b3cfd896b1d52f51c8d7186fb721718007f2fd632d65caaa204",
-        "affectsGlobalScope": false
+        "signature": "1e516b8aace99b3cfd896b1d52f51c8d7186fb721718007f2fd632d65caaa204"
       },
       "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts": {
         "version": "e655ecf9defa4207f36029831d09487233b7cb3d0af1f22cdd39bbbcc89ed242",
-        "signature": "e655ecf9defa4207f36029831d09487233b7cb3d0af1f22cdd39bbbcc89ed242",
-        "affectsGlobalScope": false
+        "signature": "e655ecf9defa4207f36029831d09487233b7cb3d0af1f22cdd39bbbcc89ed242"
       },
       "./node_modules/@lumino/polling/types/poll.d.ts": {
         "version": "ce473f99dd39a6d3df6ccd27fa99482e4195d7c64c06d75d58eec9a272a421fe",
-        "signature": "ce473f99dd39a6d3df6ccd27fa99482e4195d7c64c06d75d58eec9a272a421fe",
-        "affectsGlobalScope": false
+        "signature": "ce473f99dd39a6d3df6ccd27fa99482e4195d7c64c06d75d58eec9a272a421fe"
       },
       "./node_modules/@lumino/polling/types/ratelimiter.d.ts": {
         "version": "b666aaa284576533582a375288a6c129f261b866e6c33c392e34db0fe5b98fbd",
-        "signature": "b666aaa284576533582a375288a6c129f261b866e6c33c392e34db0fe5b98fbd",
-        "affectsGlobalScope": false
+        "signature": "b666aaa284576533582a375288a6c129f261b866e6c33c392e34db0fe5b98fbd"
       },
       "./node_modules/@lumino/polling/types/index.d.ts": {
         "version": "3800fa91e1e1a17b2d8497a388c9249bb7b7c4adb87540e71ad02c69a79d7a5c",
-        "signature": "3800fa91e1e1a17b2d8497a388c9249bb7b7c4adb87540e71ad02c69a79d7a5c",
-        "affectsGlobalScope": false
+        "signature": "3800fa91e1e1a17b2d8497a388c9249bb7b7c4adb87540e71ad02c69a79d7a5c"
       },
       "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts": {
         "version": "5af5d2530e681dfea1ca7271eee7ede8d55eb4f0f8ae12cc7f02a87b50191b1d",
-        "signature": "5af5d2530e681dfea1ca7271eee7ede8d55eb4f0f8ae12cc7f02a87b50191b1d",
-        "affectsGlobalScope": false
+        "signature": "5af5d2530e681dfea1ca7271eee7ede8d55eb4f0f8ae12cc7f02a87b50191b1d"
       },
       "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts": {
         "version": "ee46549bb25b958e351bbfeb37b4a0fb42091b5d9e95233a25000a8abeedb688",
-        "signature": "ee46549bb25b958e351bbfeb37b4a0fb42091b5d9e95233a25000a8abeedb688",
-        "affectsGlobalScope": false
+        "signature": "ee46549bb25b958e351bbfeb37b4a0fb42091b5d9e95233a25000a8abeedb688"
       },
       "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts": {
         "version": "bed01ccd9b1f468911157e9eb263866b495e9ba7ac62e28b3ebef745a818bb33",
-        "signature": "bed01ccd9b1f468911157e9eb263866b495e9ba7ac62e28b3ebef745a818bb33",
-        "affectsGlobalScope": false
+        "signature": "bed01ccd9b1f468911157e9eb263866b495e9ba7ac62e28b3ebef745a818bb33"
       },
       "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts": {
         "version": "12f4f08e2dff42ccf639ec54fd682b8f09b5cb57944f827ae271af1177086211",
-        "signature": "12f4f08e2dff42ccf639ec54fd682b8f09b5cb57944f827ae271af1177086211",
-        "affectsGlobalScope": false
+        "signature": "12f4f08e2dff42ccf639ec54fd682b8f09b5cb57944f827ae271af1177086211"
       },
       "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts": {
         "version": "64355cb023413b9f710306b65a083d3d70226c8f28e32bf866492a2c843ac641",
-        "signature": "64355cb023413b9f710306b65a083d3d70226c8f28e32bf866492a2c843ac641",
-        "affectsGlobalScope": false
+        "signature": "64355cb023413b9f710306b65a083d3d70226c8f28e32bf866492a2c843ac641"
       },
       "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts": {
         "version": "dcffdebf16fc799783c78f5333bd8dc595a8c353e6aecb3df3c8ca5a25eafecd",
-        "signature": "dcffdebf16fc799783c78f5333bd8dc595a8c353e6aecb3df3c8ca5a25eafecd",
-        "affectsGlobalScope": false
+        "signature": "dcffdebf16fc799783c78f5333bd8dc595a8c353e6aecb3df3c8ca5a25eafecd"
       },
       "./node_modules/@jupyterlab/services/lib/builder/index.d.ts": {
         "version": "7c4ca33d63aba0dd458b26f777d76ec26467537eaa7f86c6676bef45e2deb36e",
-        "signature": "7c4ca33d63aba0dd458b26f777d76ec26467537eaa7f86c6676bef45e2deb36e",
-        "affectsGlobalScope": false
+        "signature": "7c4ca33d63aba0dd458b26f777d76ec26467537eaa7f86c6676bef45e2deb36e"
       },
       "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts": {
         "version": "e3d73207d0e9c210e4a9d133a929c474f870e9d23ff0075c7d2512a107e50a5e",
-        "signature": "e3d73207d0e9c210e4a9d133a929c474f870e9d23ff0075c7d2512a107e50a5e",
-        "affectsGlobalScope": false
+        "signature": "e3d73207d0e9c210e4a9d133a929c474f870e9d23ff0075c7d2512a107e50a5e"
       },
       "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts": {
         "version": "b5575443873e492a09e84e53f65c37a24f5d291a306036f74fd34646ee9c14dd",
-        "signature": "b5575443873e492a09e84e53f65c37a24f5d291a306036f74fd34646ee9c14dd",
-        "affectsGlobalScope": false
+        "signature": "b5575443873e492a09e84e53f65c37a24f5d291a306036f74fd34646ee9c14dd"
       },
       "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts": {
         "version": "e4591a005f34ccbbbec0bd140702e243387d57a21b1d4bb6bd3e76de152fc89f",
-        "signature": "e4591a005f34ccbbbec0bd140702e243387d57a21b1d4bb6bd3e76de152fc89f",
-        "affectsGlobalScope": false
+        "signature": "e4591a005f34ccbbbec0bd140702e243387d57a21b1d4bb6bd3e76de152fc89f"
       },
       "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts": {
         "version": "377fa33e5213ba934d4350d674296c1387aa2ebd225e2a296a465bb691915884",
-        "signature": "377fa33e5213ba934d4350d674296c1387aa2ebd225e2a296a465bb691915884",
-        "affectsGlobalScope": false
+        "signature": "377fa33e5213ba934d4350d674296c1387aa2ebd225e2a296a465bb691915884"
       },
       "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts": {
         "version": "5d1af849d4efb17724b3385721ddf60944110f22a26e1e5e491a7ee5e6ae06a9",
-        "signature": "5d1af849d4efb17724b3385721ddf60944110f22a26e1e5e491a7ee5e6ae06a9",
-        "affectsGlobalScope": false
+        "signature": "5d1af849d4efb17724b3385721ddf60944110f22a26e1e5e491a7ee5e6ae06a9"
       },
       "./node_modules/@jupyterlab/coreutils/lib/path.d.ts": {
         "version": "6baff3e4e3aca45d2879a6b26369316430f8756d85319898c64c69019036ab61",
-        "signature": "6baff3e4e3aca45d2879a6b26369316430f8756d85319898c64c69019036ab61",
-        "affectsGlobalScope": false
+        "signature": "6baff3e4e3aca45d2879a6b26369316430f8756d85319898c64c69019036ab61"
       },
       "./node_modules/@jupyterlab/coreutils/lib/text.d.ts": {
         "version": "7efd9303320cf186211b14e1723172a2bc15378c0d95e49990f31be5d2f271d4",
-        "signature": "7efd9303320cf186211b14e1723172a2bc15378c0d95e49990f31be5d2f271d4",
-        "affectsGlobalScope": false
+        "signature": "7efd9303320cf186211b14e1723172a2bc15378c0d95e49990f31be5d2f271d4"
       },
       "./node_modules/@jupyterlab/coreutils/lib/time.d.ts": {
         "version": "315dfd130e525ffa1934e769dc2266bafb35d021951a7845eb145089501ed86d",
-        "signature": "315dfd130e525ffa1934e769dc2266bafb35d021951a7845eb145089501ed86d",
-        "affectsGlobalScope": false
+        "signature": "315dfd130e525ffa1934e769dc2266bafb35d021951a7845eb145089501ed86d"
       },
       "./node_modules/@jupyterlab/coreutils/lib/url.d.ts": {
         "version": "544eca475389fa55c49cac94d17a1f0e2286ea1ba0eb6599f28a513c86b04b10",
-        "signature": "544eca475389fa55c49cac94d17a1f0e2286ea1ba0eb6599f28a513c86b04b10",
-        "affectsGlobalScope": false
+        "signature": "544eca475389fa55c49cac94d17a1f0e2286ea1ba0eb6599f28a513c86b04b10"
       },
       "./node_modules/@jupyterlab/coreutils/lib/index.d.ts": {
         "version": "03b5f7f1cddded8421bccccaa7cb43c20ddde5f0d32719581a3f99fffd2fdb42",
-        "signature": "03b5f7f1cddded8421bccccaa7cb43c20ddde5f0d32719581a3f99fffd2fdb42",
-        "affectsGlobalScope": false
+        "signature": "03b5f7f1cddded8421bccccaa7cb43c20ddde5f0d32719581a3f99fffd2fdb42"
       },
       "./node_modules/@jupyterlab/services/lib/session/session.d.ts": {
         "version": "7e2865d064da62a77c2134090d4362c70a25d41dbbd43799ffe7b29798fca9a2",
-        "signature": "7e2865d064da62a77c2134090d4362c70a25d41dbbd43799ffe7b29798fca9a2",
-        "affectsGlobalScope": false
+        "signature": "7e2865d064da62a77c2134090d4362c70a25d41dbbd43799ffe7b29798fca9a2"
       },
       "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts": {
         "version": "1e376fe94028a3e12ca8c3d2db097bb6f1c9de17a72f6e854e1d512bb1734adf",
-        "signature": "1e376fe94028a3e12ca8c3d2db097bb6f1c9de17a72f6e854e1d512bb1734adf",
-        "affectsGlobalScope": false
+        "signature": "1e376fe94028a3e12ca8c3d2db097bb6f1c9de17a72f6e854e1d512bb1734adf"
       },
       "./node_modules/@jupyterlab/services/lib/session/manager.d.ts": {
         "version": "30e5c9e5ecd787438ad41ca8a487a77d6d571122c4eca365b24074eb2163964c",
-        "signature": "30e5c9e5ecd787438ad41ca8a487a77d6d571122c4eca365b24074eb2163964c",
-        "affectsGlobalScope": false
+        "signature": "30e5c9e5ecd787438ad41ca8a487a77d6d571122c4eca365b24074eb2163964c"
       },
       "./node_modules/@jupyterlab/services/lib/session/index.d.ts": {
         "version": "0214c4398c638c72f77a78bc20c16fb8fab08d9cfe2bdfcd67f0baeafcc5b02b",
-        "signature": "0214c4398c638c72f77a78bc20c16fb8fab08d9cfe2bdfcd67f0baeafcc5b02b",
-        "affectsGlobalScope": false
+        "signature": "0214c4398c638c72f77a78bc20c16fb8fab08d9cfe2bdfcd67f0baeafcc5b02b"
       },
       "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts": {
         "version": "9bfdb958a6b460d0c0c0f2781dece557cd20698820f0d4e644690dc23bc05cd9",
-        "signature": "9bfdb958a6b460d0c0c0f2781dece557cd20698820f0d4e644690dc23bc05cd9",
-        "affectsGlobalScope": false
+        "signature": "9bfdb958a6b460d0c0c0f2781dece557cd20698820f0d4e644690dc23bc05cd9"
       },
       "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts": {
         "version": "bd969829f3805c917933ef812d4cabe2c045aff801859f2c5166eb8d56aea4eb",
-        "signature": "bd969829f3805c917933ef812d4cabe2c045aff801859f2c5166eb8d56aea4eb",
-        "affectsGlobalScope": false
+        "signature": "bd969829f3805c917933ef812d4cabe2c045aff801859f2c5166eb8d56aea4eb"
       },
       "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts": {
         "version": "4c21323d9575649908d578c403dac9a3f240e839c5e0f3a7422d6bdea0d596f8",
-        "signature": "4c21323d9575649908d578c403dac9a3f240e839c5e0f3a7422d6bdea0d596f8",
-        "affectsGlobalScope": false
+        "signature": "4c21323d9575649908d578c403dac9a3f240e839c5e0f3a7422d6bdea0d596f8"
       },
       "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts": {
         "version": "2b793820a0e7d5fc41a8e3b7361a9bbb61538ccd997b3e324311dd100828830f",
-        "signature": "2b793820a0e7d5fc41a8e3b7361a9bbb61538ccd997b3e324311dd100828830f",
-        "affectsGlobalScope": false
+        "signature": "2b793820a0e7d5fc41a8e3b7361a9bbb61538ccd997b3e324311dd100828830f"
       },
       "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts": {
         "version": "f8c57de65d7a1c151041621bf9ed1cc3da20ffb5bd004182e4e04dbbaa21e41e",
-        "signature": "f8c57de65d7a1c151041621bf9ed1cc3da20ffb5bd004182e4e04dbbaa21e41e",
-        "affectsGlobalScope": false
+        "signature": "f8c57de65d7a1c151041621bf9ed1cc3da20ffb5bd004182e4e04dbbaa21e41e"
       },
       "./node_modules/@jupyterlab/statedb/lib/index.d.ts": {
         "version": "ea3d38e208051abbe4045b494f6988e326a6f41d28f06a4e6fc097f9f4b51581",
-        "signature": "ea3d38e208051abbe4045b494f6988e326a6f41d28f06a4e6fc097f9f4b51581",
-        "affectsGlobalScope": false
+        "signature": "ea3d38e208051abbe4045b494f6988e326a6f41d28f06a4e6fc097f9f4b51581"
       },
       "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts": {
         "version": "7245409212bcb5f3067cc961cc52dd924c672e6d4af5ef2e82bf5d64ab3f8a1b",
-        "signature": "7245409212bcb5f3067cc961cc52dd924c672e6d4af5ef2e82bf5d64ab3f8a1b",
-        "affectsGlobalScope": false
+        "signature": "7245409212bcb5f3067cc961cc52dd924c672e6d4af5ef2e82bf5d64ab3f8a1b"
       },
       "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts": {
         "version": "22a8af7501bb57fc431c7a7429140aa4d378dc8cfd2784011d737be26990eddb",
-        "signature": "22a8af7501bb57fc431c7a7429140aa4d378dc8cfd2784011d737be26990eddb",
-        "affectsGlobalScope": false
+        "signature": "22a8af7501bb57fc431c7a7429140aa4d378dc8cfd2784011d737be26990eddb"
       },
       "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts": {
         "version": "a4dfd64a8c7aad8447b5d01ad3e26be000862bf038d0f1b9ba65bad972510171",
-        "signature": "a4dfd64a8c7aad8447b5d01ad3e26be000862bf038d0f1b9ba65bad972510171",
-        "affectsGlobalScope": false
+        "signature": "a4dfd64a8c7aad8447b5d01ad3e26be000862bf038d0f1b9ba65bad972510171"
       },
       "./node_modules/@jupyterlab/services/lib/setting/index.d.ts": {
         "version": "3f60325f8360846557509a160b9211c90419c4325581b04d3bd6fbe8a0972f9e",
-        "signature": "3f60325f8360846557509a160b9211c90419c4325581b04d3bd6fbe8a0972f9e",
-        "affectsGlobalScope": false
+        "signature": "3f60325f8360846557509a160b9211c90419c4325581b04d3bd6fbe8a0972f9e"
       },
       "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts": {
         "version": "ad222cd4778885952eb6624fcd2348c2105d8293dcb4326ca15583f859c78747",
-        "signature": "ad222cd4778885952eb6624fcd2348c2105d8293dcb4326ca15583f859c78747",
-        "affectsGlobalScope": false
+        "signature": "ad222cd4778885952eb6624fcd2348c2105d8293dcb4326ca15583f859c78747"
       },
       "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts": {
         "version": "a2feee4df1f1d753bcbd3c433c21c8448a1ac0056e3ac9be4cc27a03fbace276",
-        "signature": "a2feee4df1f1d753bcbd3c433c21c8448a1ac0056e3ac9be4cc27a03fbace276",
-        "affectsGlobalScope": false
+        "signature": "a2feee4df1f1d753bcbd3c433c21c8448a1ac0056e3ac9be4cc27a03fbace276"
       },
       "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts": {
         "version": "6bfbf1f9ad12ab0b95cf1c41468f90c006bc5d10fc4dccc9a875854f14f9dd61",
-        "signature": "6bfbf1f9ad12ab0b95cf1c41468f90c006bc5d10fc4dccc9a875854f14f9dd61",
-        "affectsGlobalScope": false
+        "signature": "6bfbf1f9ad12ab0b95cf1c41468f90c006bc5d10fc4dccc9a875854f14f9dd61"
       },
       "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts": {
         "version": "77a4cfb8baa8f9861178b8ff4de8409841b387cd73ea4e51e2beee758c2d818a",
-        "signature": "77a4cfb8baa8f9861178b8ff4de8409841b387cd73ea4e51e2beee758c2d818a",
-        "affectsGlobalScope": false
+        "signature": "77a4cfb8baa8f9861178b8ff4de8409841b387cd73ea4e51e2beee758c2d818a"
       },
       "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts": {
         "version": "41238e64af8893e3b433f15a8b0effc87e1510c11cb5d157dde0e06411247398",
-        "signature": "41238e64af8893e3b433f15a8b0effc87e1510c11cb5d157dde0e06411247398",
-        "affectsGlobalScope": false
+        "signature": "41238e64af8893e3b433f15a8b0effc87e1510c11cb5d157dde0e06411247398"
       },
       "./node_modules/@jupyterlab/services/lib/manager.d.ts": {
         "version": "fdbe60857d35ec916e210e581890f5387e885d0e73e8c6fb62052bad05362bb8",
-        "signature": "fdbe60857d35ec916e210e581890f5387e885d0e73e8c6fb62052bad05362bb8",
-        "affectsGlobalScope": false
+        "signature": "fdbe60857d35ec916e210e581890f5387e885d0e73e8c6fb62052bad05362bb8"
       },
       "./node_modules/@jupyterlab/services/lib/index.d.ts": {
         "version": "7b33ecaba2fcfd2ddda40d6bea6a5f2b71ef1eff6e31990ab6800b8708ea3da4",
-        "signature": "7b33ecaba2fcfd2ddda40d6bea6a5f2b71ef1eff6e31990ab6800b8708ea3da4",
-        "affectsGlobalScope": false
+        "signature": "7b33ecaba2fcfd2ddda40d6bea6a5f2b71ef1eff6e31990ab6800b8708ea3da4"
       },
       "./node_modules/@jupyterlab/application/lib/tokens.d.ts": {
         "version": "9888b829d8bd7ba8759dacb2dff0d539fecdd90d2ad850d71273058b4320d15b",
-        "signature": "9888b829d8bd7ba8759dacb2dff0d539fecdd90d2ad850d71273058b4320d15b",
-        "affectsGlobalScope": false
+        "signature": "9888b829d8bd7ba8759dacb2dff0d539fecdd90d2ad850d71273058b4320d15b"
       },
       "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts": {
         "version": "4078af51a426601e46cedc694ee3d046b5a144397872dd3f245b9dddd204c8b4",
-        "signature": "4078af51a426601e46cedc694ee3d046b5a144397872dd3f245b9dddd204c8b4",
-        "affectsGlobalScope": false
+        "signature": "4078af51a426601e46cedc694ee3d046b5a144397872dd3f245b9dddd204c8b4"
       },
       "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts": {
         "version": "b9a2b4d2c1040298a3940b1f904553904336c6618bd87aaefa9e170b0b9331e9",
-        "signature": "b9a2b4d2c1040298a3940b1f904553904336c6618bd87aaefa9e170b0b9331e9",
-        "affectsGlobalScope": false
+        "signature": "b9a2b4d2c1040298a3940b1f904553904336c6618bd87aaefa9e170b0b9331e9"
       },
       "./node_modules/@lumino/widgets/types/boxengine.d.ts": {
         "version": "6ce99f2c6e7c79a0b467e93cc607909fdeea4075ac24b2ea26df81c756c91197",
-        "signature": "6ce99f2c6e7c79a0b467e93cc607909fdeea4075ac24b2ea26df81c756c91197",
-        "affectsGlobalScope": false
+        "signature": "6ce99f2c6e7c79a0b467e93cc607909fdeea4075ac24b2ea26df81c756c91197"
       },
       "./node_modules/@lumino/widgets/types/title.d.ts": {
         "version": "069430905191c1c7d58b608084a53b30584aa0c8a60134787578161ec8cafc72",
-        "signature": "069430905191c1c7d58b608084a53b30584aa0c8a60134787578161ec8cafc72",
-        "affectsGlobalScope": false
+        "signature": "069430905191c1c7d58b608084a53b30584aa0c8a60134787578161ec8cafc72"
       },
       "./node_modules/@lumino/widgets/types/widget.d.ts": {
         "version": "813737a8cd7bd632b12d427e288818157c5dd79beadcd7930c55aeb7ff75668e",
-        "signature": "813737a8cd7bd632b12d427e288818157c5dd79beadcd7930c55aeb7ff75668e",
-        "affectsGlobalScope": false
+        "signature": "813737a8cd7bd632b12d427e288818157c5dd79beadcd7930c55aeb7ff75668e"
       },
       "./node_modules/@lumino/widgets/types/layout.d.ts": {
         "version": "9606217cee9da6af32701c4a4ec62c5e1c08a8c81e9b40444bd02007981f35ad",
-        "signature": "9606217cee9da6af32701c4a4ec62c5e1c08a8c81e9b40444bd02007981f35ad",
-        "affectsGlobalScope": false
+        "signature": "9606217cee9da6af32701c4a4ec62c5e1c08a8c81e9b40444bd02007981f35ad"
       },
       "./node_modules/@lumino/widgets/types/panellayout.d.ts": {
         "version": "b6fe9902db09a08fb5816c2644d47b21b48763a6493d1f2080dcc8f97f63ffd5",
-        "signature": "b6fe9902db09a08fb5816c2644d47b21b48763a6493d1f2080dcc8f97f63ffd5",
-        "affectsGlobalScope": false
+        "signature": "b6fe9902db09a08fb5816c2644d47b21b48763a6493d1f2080dcc8f97f63ffd5"
       },
       "./node_modules/@lumino/widgets/types/boxlayout.d.ts": {
         "version": "094bc98f1966930b9b31f714ff4689cc2282348d2ac06614d2dfa3e3a0dd2bee",
-        "signature": "094bc98f1966930b9b31f714ff4689cc2282348d2ac06614d2dfa3e3a0dd2bee",
-        "affectsGlobalScope": false
+        "signature": "094bc98f1966930b9b31f714ff4689cc2282348d2ac06614d2dfa3e3a0dd2bee"
       },
       "./node_modules/@lumino/widgets/types/panel.d.ts": {
         "version": "4ea4e4aeb7cc473d641ec53cc7a05324ff1c528e452e1a0f5949a245911d4775",
-        "signature": "4ea4e4aeb7cc473d641ec53cc7a05324ff1c528e452e1a0f5949a245911d4775",
-        "affectsGlobalScope": false
+        "signature": "4ea4e4aeb7cc473d641ec53cc7a05324ff1c528e452e1a0f5949a245911d4775"
       },
       "./node_modules/@lumino/widgets/types/boxpanel.d.ts": {
         "version": "eb0acd32fc29c07e864c737a4811b71159e03833b36febb85f7e47259d87e135",
-        "signature": "eb0acd32fc29c07e864c737a4811b71159e03833b36febb85f7e47259d87e135",
-        "affectsGlobalScope": false
+        "signature": "eb0acd32fc29c07e864c737a4811b71159e03833b36febb85f7e47259d87e135"
       },
       "./node_modules/@lumino/widgets/types/commandpalette.d.ts": {
-        "version": "05d9a8f0c106e662d8dfea3d5fdda3d736b5b01cf07504df026ebdd5b0a6777a",
-        "signature": "05d9a8f0c106e662d8dfea3d5fdda3d736b5b01cf07504df026ebdd5b0a6777a",
-        "affectsGlobalScope": false
+        "version": "8822abe51f52f5334688a69a294bcbf49530dd1c33b87692420b8e3c40fc84dd",
+        "signature": "8822abe51f52f5334688a69a294bcbf49530dd1c33b87692420b8e3c40fc84dd"
       },
       "./node_modules/@lumino/widgets/types/menu.d.ts": {
-        "version": "a84fdd5325d4dc7e2adff61b951529ae6e168edd476c90e7003e959d5398a8f8",
-        "signature": "a84fdd5325d4dc7e2adff61b951529ae6e168edd476c90e7003e959d5398a8f8",
-        "affectsGlobalScope": false
+        "version": "14085068ef67e9c4dea4eea0f137315a3f30f4fdf9809db64c9ca66d78af8e4e",
+        "signature": "14085068ef67e9c4dea4eea0f137315a3f30f4fdf9809db64c9ca66d78af8e4e"
       },
       "./node_modules/@lumino/widgets/types/contextmenu.d.ts": {
         "version": "0408afb474542f58f54367587274e5363d622293e7610e7b811242a00ae4d2fe",
-        "signature": "0408afb474542f58f54367587274e5363d622293e7610e7b811242a00ae4d2fe",
-        "affectsGlobalScope": false
+        "signature": "0408afb474542f58f54367587274e5363d622293e7610e7b811242a00ae4d2fe"
       },
       "./node_modules/@lumino/widgets/types/tabbar.d.ts": {
-        "version": "c682cc00d8f9a412414ab3907b3677d19e09447ed96cd3ed0282b15ba7db566d",
-        "signature": "c682cc00d8f9a412414ab3907b3677d19e09447ed96cd3ed0282b15ba7db566d",
-        "affectsGlobalScope": false
+        "version": "8752ebc7aa2662b0e669ca430dbf6828f1a406f45fb43b376359a7f7be68b270",
+        "signature": "8752ebc7aa2662b0e669ca430dbf6828f1a406f45fb43b376359a7f7be68b270"
       },
       "./node_modules/@lumino/widgets/types/docklayout.d.ts": {
         "version": "7f844465fd87097c35cf3cb13cc77e28c8e7429eab6750c4a49500125b6e48b2",
-        "signature": "7f844465fd87097c35cf3cb13cc77e28c8e7429eab6750c4a49500125b6e48b2",
-        "affectsGlobalScope": false
+        "signature": "7f844465fd87097c35cf3cb13cc77e28c8e7429eab6750c4a49500125b6e48b2"
       },
       "./node_modules/@lumino/widgets/types/dockpanel.d.ts": {
-        "version": "cac95c328a04ebcce9b6ff3afb8d64d6d6c0964e99e0542ec7529784d8f75dc8",
-        "signature": "cac95c328a04ebcce9b6ff3afb8d64d6d6c0964e99e0542ec7529784d8f75dc8",
-        "affectsGlobalScope": false
+        "version": "830fe4d372aefc894975a40a4153a4bffe86835e504a11eac4d95bf872de5f68",
+        "signature": "830fe4d372aefc894975a40a4153a4bffe86835e504a11eac4d95bf872de5f68"
       },
       "./node_modules/@lumino/widgets/types/focustracker.d.ts": {
         "version": "a7c7b25084276be11aa983dbf29f39892db6c521b85433f598717921bf64d08e",
-        "signature": "a7c7b25084276be11aa983dbf29f39892db6c521b85433f598717921bf64d08e",
-        "affectsGlobalScope": false
+        "signature": "a7c7b25084276be11aa983dbf29f39892db6c521b85433f598717921bf64d08e"
       },
       "./node_modules/@lumino/widgets/types/gridlayout.d.ts": {
         "version": "9d3fb450742b3f5c5f459177e70fa3c4c4ab52d0b4215be87cfcdf5fc8685ad2",
-        "signature": "9d3fb450742b3f5c5f459177e70fa3c4c4ab52d0b4215be87cfcdf5fc8685ad2",
-        "affectsGlobalScope": false
+        "signature": "9d3fb450742b3f5c5f459177e70fa3c4c4ab52d0b4215be87cfcdf5fc8685ad2"
       },
       "./node_modules/@lumino/widgets/types/menubar.d.ts": {
-        "version": "0676ad817bf1b4c310e58ce87e32fd9fa6f9229c6a2a6b5d5f7e92b09b7bfa77",
-        "signature": "0676ad817bf1b4c310e58ce87e32fd9fa6f9229c6a2a6b5d5f7e92b09b7bfa77",
-        "affectsGlobalScope": false
+        "version": "781725f0dd4a10edd6efbf26e7fab87e86f8aa4e60c1bb3108df81deb3c87409",
+        "signature": "781725f0dd4a10edd6efbf26e7fab87e86f8aa4e60c1bb3108df81deb3c87409"
       },
       "./node_modules/@lumino/widgets/types/scrollbar.d.ts": {
         "version": "ff8fce615e42a7a40d34fd1110488663bc010469e7cd3d21df8ddda06f6ebd95",
-        "signature": "ff8fce615e42a7a40d34fd1110488663bc010469e7cd3d21df8ddda06f6ebd95",
-        "affectsGlobalScope": false
+        "signature": "ff8fce615e42a7a40d34fd1110488663bc010469e7cd3d21df8ddda06f6ebd95"
       },
       "./node_modules/@lumino/widgets/types/singletonlayout.d.ts": {
         "version": "cb114e95d686eadc19feda14f7ae0c497fd060415cf669d4062447ef22b54e93",
-        "signature": "cb114e95d686eadc19feda14f7ae0c497fd060415cf669d4062447ef22b54e93",
-        "affectsGlobalScope": false
+        "signature": "cb114e95d686eadc19feda14f7ae0c497fd060415cf669d4062447ef22b54e93"
       },
       "./node_modules/@lumino/widgets/types/splitlayout.d.ts": {
         "version": "115b150e7d81fb2e80d204b7f1082c13fd9650195da846a74f6f2b43b022579e",
-        "signature": "115b150e7d81fb2e80d204b7f1082c13fd9650195da846a74f6f2b43b022579e",
-        "affectsGlobalScope": false
+        "signature": "115b150e7d81fb2e80d204b7f1082c13fd9650195da846a74f6f2b43b022579e"
       },
       "./node_modules/@lumino/widgets/types/splitpanel.d.ts": {
         "version": "bd5604d87894ac046a5f017c1fd820f15fcf70d58ac7db47e537205cf5a9f80d",
-        "signature": "bd5604d87894ac046a5f017c1fd820f15fcf70d58ac7db47e537205cf5a9f80d",
-        "affectsGlobalScope": false
+        "signature": "bd5604d87894ac046a5f017c1fd820f15fcf70d58ac7db47e537205cf5a9f80d"
       },
       "./node_modules/@lumino/widgets/types/stackedlayout.d.ts": {
         "version": "c7e1800b0e4e0914d2109b02cc4efa98c3fb79acb98f6a9a0dd5c1311576a42f",
-        "signature": "c7e1800b0e4e0914d2109b02cc4efa98c3fb79acb98f6a9a0dd5c1311576a42f",
-        "affectsGlobalScope": false
+        "signature": "c7e1800b0e4e0914d2109b02cc4efa98c3fb79acb98f6a9a0dd5c1311576a42f"
       },
       "./node_modules/@lumino/widgets/types/stackedpanel.d.ts": {
         "version": "c94759a4b4d2f1044f2b03f3057319194739841524d22aa73b13e556a99bef5c",
-        "signature": "c94759a4b4d2f1044f2b03f3057319194739841524d22aa73b13e556a99bef5c",
-        "affectsGlobalScope": false
+        "signature": "c94759a4b4d2f1044f2b03f3057319194739841524d22aa73b13e556a99bef5c"
       },
       "./node_modules/@lumino/widgets/types/tabpanel.d.ts": {
         "version": "887ef5e98f4b329f3ddf17864d45a9f2ee82608aa43666f95863b690e261a1ee",
-        "signature": "887ef5e98f4b329f3ddf17864d45a9f2ee82608aa43666f95863b690e261a1ee",
-        "affectsGlobalScope": false
+        "signature": "887ef5e98f4b329f3ddf17864d45a9f2ee82608aa43666f95863b690e261a1ee"
       },
       "./node_modules/@lumino/widgets/types/index.d.ts": {
         "version": "3575fd6e7b41c7b983d39ae80434267391f78d28b48a8af78f9f26e4535de01b",
-        "signature": "3575fd6e7b41c7b983d39ae80434267391f78d28b48a8af78f9f26e4535de01b",
-        "affectsGlobalScope": false
+        "signature": "3575fd6e7b41c7b983d39ae80434267391f78d28b48a8af78f9f26e4535de01b"
       },
       "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts": {
         "version": "147d833a2c635e5e69bcf63b33bbbd07fc47cd95d012d8199a132c8e63a78f05",
-        "signature": "147d833a2c635e5e69bcf63b33bbbd07fc47cd95d012d8199a132c8e63a78f05",
-        "affectsGlobalScope": false
+        "signature": "147d833a2c635e5e69bcf63b33bbbd07fc47cd95d012d8199a132c8e63a78f05"
       },
       "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts": {
         "version": "676021e3da2688edca83e863d280c6357469695504a49575b9dd6cea808d4b0d",
-        "signature": "676021e3da2688edca83e863d280c6357469695504a49575b9dd6cea808d4b0d",
-        "affectsGlobalScope": false
+        "signature": "676021e3da2688edca83e863d280c6357469695504a49575b9dd6cea808d4b0d"
       },
       "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts": {
         "version": "1b7f615feb294fc2ad1be090c373e43b5eb3bcb519901605f60c561de2038d4e",
-        "signature": "1b7f615feb294fc2ad1be090c373e43b5eb3bcb519901605f60c561de2038d4e",
-        "affectsGlobalScope": false
+        "signature": "1b7f615feb294fc2ad1be090c373e43b5eb3bcb519901605f60c561de2038d4e"
       },
       "./node_modules/@types/react/global.d.ts": {
         "version": "ecf78e637f710f340ec08d5d92b3f31b134a46a4fcf2e758690d8c46ce62cba6",
-        "signature": "ecf78e637f710f340ec08d5d92b3f31b134a46a4fcf2e758690d8c46ce62cba6",
-        "affectsGlobalScope": true
+        "signature": "ecf78e637f710f340ec08d5d92b3f31b134a46a4fcf2e758690d8c46ce62cba6"
       },
-      "./node_modules/csstype/index.d.ts": {
-        "version": "f9d66b7d0c140496459807082ebe1bd8185a2d7478951881724b708e72fc7386",
-        "signature": "f9d66b7d0c140496459807082ebe1bd8185a2d7478951881724b708e72fc7386",
-        "affectsGlobalScope": false
+      "./node_modules/@types/react/node_modules/csstype/index.d.ts": {
+        "version": "ea58e4cbcf3d760a15f9300978a360c46360f544b355c737b60c733a385b8858",
+        "signature": "ea58e4cbcf3d760a15f9300978a360c46360f544b355c737b60c733a385b8858"
       },
       "./node_modules/@types/prop-types/index.d.ts": {
         "version": "a7e32dcb90bf0c1b7a1e4ac89b0f7747cbcba25e7beddc1ebf17be1e161842ad",
-        "signature": "a7e32dcb90bf0c1b7a1e4ac89b0f7747cbcba25e7beddc1ebf17be1e161842ad",
-        "affectsGlobalScope": false
+        "signature": "a7e32dcb90bf0c1b7a1e4ac89b0f7747cbcba25e7beddc1ebf17be1e161842ad"
       },
       "./node_modules/@types/react/index.d.ts": {
-        "version": "081425611368b52c9c42d36ac1ac14287f20521f10447f7dd4f4174143e375fd",
-        "signature": "081425611368b52c9c42d36ac1ac14287f20521f10447f7dd4f4174143e375fd",
-        "affectsGlobalScope": true
+        "version": "416e5d547a57e2fc9bac063ff167eee2c34aad14296acf9688eaa24fee981e05",
+        "signature": "416e5d547a57e2fc9bac063ff167eee2c34aad14296acf9688eaa24fee981e05"
       },
       "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts": {
         "version": "47373ee1335c841b028086f19214476c62380d6db1061331b365fb03a77131c6",
-        "signature": "47373ee1335c841b028086f19214476c62380d6db1061331b365fb03a77131c6",
-        "affectsGlobalScope": false
+        "signature": "47373ee1335c841b028086f19214476c62380d6db1061331b365fb03a77131c6"
       },
       "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts": {
         "version": "91a15e59f6573899755512a831eccac6fdf287b6225935f59c74563e1c2c5431",
-        "signature": "91a15e59f6573899755512a831eccac6fdf287b6225935f59c74563e1c2c5431",
-        "affectsGlobalScope": false
+        "signature": "91a15e59f6573899755512a831eccac6fdf287b6225935f59c74563e1c2c5431"
       },
       "./node_modules/@jupyterlab/apputils/lib/domutils.d.ts": {
         "version": "b8a6b60217ac1eb177c22d3e78878387fb9b4326d9c42d48e7db569f397609c6",
-        "signature": "b8a6b60217ac1eb177c22d3e78878387fb9b4326d9c42d48e7db569f397609c6",
-        "affectsGlobalScope": false
+        "signature": "b8a6b60217ac1eb177c22d3e78878387fb9b4326d9c42d48e7db569f397609c6"
       },
       "./node_modules/@jupyterlab/apputils/lib/hoverbox.d.ts": {
         "version": "1aeef85f101d6623640784d3208baa1c01922a891d8da0bbdc1439f0863d3656",
-        "signature": "1aeef85f101d6623640784d3208baa1c01922a891d8da0bbdc1439f0863d3656",
-        "affectsGlobalScope": false
+        "signature": "1aeef85f101d6623640784d3208baa1c01922a891d8da0bbdc1439f0863d3656"
       },
       "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts": {
         "version": "65e5cb9e3b27c94401ae27b67752f7c782f7ef7fbade7705ac9c6e2ac9034125",
-        "signature": "65e5cb9e3b27c94401ae27b67752f7c782f7ef7fbade7705ac9c6e2ac9034125",
-        "affectsGlobalScope": false
+        "signature": "65e5cb9e3b27c94401ae27b67752f7c782f7ef7fbade7705ac9c6e2ac9034125"
       },
       "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts": {
         "version": "ce3504946dfdd742270be199cc1cdbb6bc3e2f5c1d321aab6c3f015dfa9ad7cd",
-        "signature": "ce3504946dfdd742270be199cc1cdbb6bc3e2f5c1d321aab6c3f015dfa9ad7cd",
-        "affectsGlobalScope": false
+        "signature": "ce3504946dfdd742270be199cc1cdbb6bc3e2f5c1d321aab6c3f015dfa9ad7cd"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts": {
         "version": "b19f59a453f22453e4735e0b9fee2089fabebddfdd0b0fedab0409e3a2da63ca",
-        "signature": "b19f59a453f22453e4735e0b9fee2089fabebddfdd0b0fedab0409e3a2da63ca",
-        "affectsGlobalScope": false
+        "signature": "b19f59a453f22453e4735e0b9fee2089fabebddfdd0b0fedab0409e3a2da63ca"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts": {
         "version": "4c3968c463988e5d3139ffb9f8d6594322f4db786a8ee51e6613b8d2eec7eaec",
-        "signature": "4c3968c463988e5d3139ffb9f8d6594322f4db786a8ee51e6613b8d2eec7eaec",
-        "affectsGlobalScope": false
+        "signature": "4c3968c463988e5d3139ffb9f8d6594322f4db786a8ee51e6613b8d2eec7eaec"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts": {
         "version": "39fc830ce91c93ba086d587f36d8c6e95d46d1ed03ba05d36ef0021097459390",
-        "signature": "39fc830ce91c93ba086d587f36d8c6e95d46d1ed03ba05d36ef0021097459390",
-        "affectsGlobalScope": false
+        "signature": "39fc830ce91c93ba086d587f36d8c6e95d46d1ed03ba05d36ef0021097459390"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts": {
         "version": "d17f7a001dae13ded8536376f9319169a4c53e0e3789756e2058d0f4b4083a19",
-        "signature": "d17f7a001dae13ded8536376f9319169a4c53e0e3789756e2058d0f4b4083a19",
-        "affectsGlobalScope": false
+        "signature": "d17f7a001dae13ded8536376f9319169a4c53e0e3789756e2058d0f4b4083a19"
+      },
+      "./node_modules/csstype/index.d.ts": {
+        "version": "f9d66b7d0c140496459807082ebe1bd8185a2d7478951881724b708e72fc7386",
+        "signature": "f9d66b7d0c140496459807082ebe1bd8185a2d7478951881724b708e72fc7386"
       },
       "./node_modules/typestyle/lib/types.d.ts": {
         "version": "aca6c5506e2023b46af62d650a80e2c3596b7d4d77e8ec82dd9345604230640f",
-        "signature": "aca6c5506e2023b46af62d650a80e2c3596b7d4d77e8ec82dd9345604230640f",
-        "affectsGlobalScope": false
+        "signature": "aca6c5506e2023b46af62d650a80e2c3596b7d4d77e8ec82dd9345604230640f"
       },
       "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts": {
         "version": "72197af93cb407921c0db36a7c187588c10f994e7924d2ec722004843c226e2d",
-        "signature": "72197af93cb407921c0db36a7c187588c10f994e7924d2ec722004843c226e2d",
-        "affectsGlobalScope": false
+        "signature": "72197af93cb407921c0db36a7c187588c10f994e7924d2ec722004843c226e2d"
       },
       "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts": {
         "version": "aecf31d8843eecf4011a77ba692a68ba8da0241653a39cd275310eed2ab1649d",
-        "signature": "aecf31d8843eecf4011a77ba692a68ba8da0241653a39cd275310eed2ab1649d",
-        "affectsGlobalScope": false
+        "signature": "aecf31d8843eecf4011a77ba692a68ba8da0241653a39cd275310eed2ab1649d"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts": {
         "version": "d5dc25c69cda858bec2354a3019de2daa0225beb9feb9fdb4439d9633ab2d202",
-        "signature": "d5dc25c69cda858bec2354a3019de2daa0225beb9feb9fdb4439d9633ab2d202",
-        "affectsGlobalScope": false
+        "signature": "d5dc25c69cda858bec2354a3019de2daa0225beb9feb9fdb4439d9633ab2d202"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts": {
         "version": "c9780af8da73a8b086d7f0b9d6b96a3e6c6c98cddf9469dd5608c60d0b34478d",
-        "signature": "c9780af8da73a8b086d7f0b9d6b96a3e6c6c98cddf9469dd5608c60d0b34478d",
-        "affectsGlobalScope": false
+        "signature": "c9780af8da73a8b086d7f0b9d6b96a3e6c6c98cddf9469dd5608c60d0b34478d"
       },
       "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts": {
         "version": "2c10d415e99427cb5afcf7b00ab2f15879e5fd7fec14260dcc2b2ad811edb41f",
-        "signature": "2c10d415e99427cb5afcf7b00ab2f15879e5fd7fec14260dcc2b2ad811edb41f",
-        "affectsGlobalScope": false
+        "signature": "2c10d415e99427cb5afcf7b00ab2f15879e5fd7fec14260dcc2b2ad811edb41f"
       },
       "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts": {
         "version": "db3efaf54928d3b92c0e80f1da14e03b49e20272e90158beae18ac9891207798",
-        "signature": "db3efaf54928d3b92c0e80f1da14e03b49e20272e90158beae18ac9891207798",
-        "affectsGlobalScope": false
+        "signature": "db3efaf54928d3b92c0e80f1da14e03b49e20272e90158beae18ac9891207798"
       },
       "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts": {
         "version": "cb82c1784b85fe06df3a5bdbebf3e27e68ed9e6e0086014db89adf3954596661",
-        "signature": "cb82c1784b85fe06df3a5bdbebf3e27e68ed9e6e0086014db89adf3954596661",
-        "affectsGlobalScope": false
+        "signature": "cb82c1784b85fe06df3a5bdbebf3e27e68ed9e6e0086014db89adf3954596661"
       },
       "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts": {
         "version": "27c2f3f7b0f4aa6c686ce682501cbbfb5fe9ca1d93071be7f334db230624269c",
-        "signature": "27c2f3f7b0f4aa6c686ce682501cbbfb5fe9ca1d93071be7f334db230624269c",
-        "affectsGlobalScope": false
+        "signature": "27c2f3f7b0f4aa6c686ce682501cbbfb5fe9ca1d93071be7f334db230624269c"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts": {
-        "version": "b2cabd671bc6ac4fe56661911667354ddb1a63e80ee21233f92580e917f6901a",
-        "signature": "b2cabd671bc6ac4fe56661911667354ddb1a63e80ee21233f92580e917f6901a",
-        "affectsGlobalScope": false
+        "version": "5fd0825b158c7aa174fa18a3bf032d189825da2e4f507b06aa6d0575b59628d5",
+        "signature": "5fd0825b158c7aa174fa18a3bf032d189825da2e4f507b06aa6d0575b59628d5"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts": {
-        "version": "71dee7372e749bf96df66de3d2231e4efb6c3965c01f1452326f41211d704b6b",
-        "signature": "71dee7372e749bf96df66de3d2231e4efb6c3965c01f1452326f41211d704b6b",
-        "affectsGlobalScope": false
+        "version": "866eb7ec572ba83cf0ef4f6ad2017be77b831afe2354e8c073afc1fbd8ce8fee",
+        "signature": "866eb7ec572ba83cf0ef4f6ad2017be77b831afe2354e8c073afc1fbd8ce8fee"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts": {
-        "version": "bd1bb89e16763711c3afdb4fc689e2fa9277a1a31e7fb01d813d2db7ca43636d",
-        "signature": "bd1bb89e16763711c3afdb4fc689e2fa9277a1a31e7fb01d813d2db7ca43636d",
-        "affectsGlobalScope": false
+        "version": "d0d683bd9f2b172c6bcafeff6205e747bd546ad1fe4b865c4d6342362d24ddf6",
+        "signature": "d0d683bd9f2b172c6bcafeff6205e747bd546ad1fe4b865c4d6342362d24ddf6"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts": {
-        "version": "f76c24e0612f9cafc3ef5b2d091a2afc8ee8fe0b12d1785fa0c920a77e435244",
-        "signature": "f76c24e0612f9cafc3ef5b2d091a2afc8ee8fe0b12d1785fa0c920a77e435244",
-        "affectsGlobalScope": false
+        "version": "d8f3ca2ceadb316ebf9f55b0fa1366d0ce44c768238f6e5369e05987ca0ce6f1",
+        "signature": "d8f3ca2ceadb316ebf9f55b0fa1366d0ce44c768238f6e5369e05987ca0ce6f1"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts": {
-        "version": "88de9a9c98584364f427af57e91b6ecb9c1a375b15a19120997754e6c7d33919",
-        "signature": "88de9a9c98584364f427af57e91b6ecb9c1a375b15a19120997754e6c7d33919",
-        "affectsGlobalScope": false
+        "version": "496b87c1158f9475e5216e01583f5bb1b98f6323f6ab7a899898d624a874e585",
+        "signature": "496b87c1158f9475e5216e01583f5bb1b98f6323f6ab7a899898d624a874e585"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts": {
         "version": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88",
-        "signature": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88",
-        "affectsGlobalScope": false
+        "signature": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts": {
         "version": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6",
-        "signature": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6",
-        "affectsGlobalScope": false
+        "signature": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts": {
         "version": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64",
-        "signature": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64",
-        "affectsGlobalScope": false
+        "signature": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts": {
         "version": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420",
-        "signature": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420",
-        "affectsGlobalScope": false
+        "signature": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts": {
         "version": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b",
-        "signature": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b",
-        "affectsGlobalScope": false
+        "signature": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts": {
         "version": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558",
-        "signature": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558",
-        "affectsGlobalScope": false
+        "signature": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts": {
         "version": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8",
-        "signature": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8",
-        "affectsGlobalScope": false
+        "signature": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8"
       },
       "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts": {
         "version": "e133efe7fd5a1467149abf111686337d3e65d61d7f38e13ba5a6134201315958",
-        "signature": "e133efe7fd5a1467149abf111686337d3e65d61d7f38e13ba5a6134201315958",
-        "affectsGlobalScope": false
+        "signature": "e133efe7fd5a1467149abf111686337d3e65d61d7f38e13ba5a6134201315958"
       },
       "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts": {
-        "version": "bb341c1e52fdbccd2697cfaff2b5aedeea07fdf1cb85f0ba69a4f4def67be76e",
-        "signature": "bb341c1e52fdbccd2697cfaff2b5aedeea07fdf1cb85f0ba69a4f4def67be76e",
-        "affectsGlobalScope": false
+        "version": "a5a36391ddc1734030fc630f6ca556ceee1fc01f30d00d64d8af45516c2afccb",
+        "signature": "a5a36391ddc1734030fc630f6ca556ceee1fc01f30d00d64d8af45516c2afccb"
       },
       "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts": {
         "version": "f83b02a0e5d2ea81b9a14362a1cadafd534392bacdf731e461afc330c476980d",
-        "signature": "f83b02a0e5d2ea81b9a14362a1cadafd534392bacdf731e461afc330c476980d",
-        "affectsGlobalScope": false
+        "signature": "f83b02a0e5d2ea81b9a14362a1cadafd534392bacdf731e461afc330c476980d"
       },
       "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts": {
         "version": "f634926161579868440ca5372c890f0e20200b1323af31802a7075c4efdabe04",
-        "signature": "f634926161579868440ca5372c890f0e20200b1323af31802a7075c4efdabe04",
-        "affectsGlobalScope": false
+        "signature": "f634926161579868440ca5372c890f0e20200b1323af31802a7075c4efdabe04"
       },
       "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts": {
         "version": "9954e278f4c8a55b3c70710fc601addf02cf0a3eeccfb1b569917f10e3899a20",
-        "signature": "9954e278f4c8a55b3c70710fc601addf02cf0a3eeccfb1b569917f10e3899a20",
-        "affectsGlobalScope": false
+        "signature": "9954e278f4c8a55b3c70710fc601addf02cf0a3eeccfb1b569917f10e3899a20"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts": {
-        "version": "27f2e8f96442bee1380a2b36ee79fcaa03965463eedca581aa17a553b08091ef",
-        "signature": "27f2e8f96442bee1380a2b36ee79fcaa03965463eedca581aa17a553b08091ef",
-        "affectsGlobalScope": false
+        "version": "bfee6627661665286f81224b067147803ddf7a9f5a00bdd4b9927860dd03159e",
+        "signature": "bfee6627661665286f81224b067147803ddf7a9f5a00bdd4b9927860dd03159e"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts": {
-        "version": "c83307af3022a3718c11180a153136010e22dd328c7f9a8cb4793bfe000e0f15",
-        "signature": "c83307af3022a3718c11180a153136010e22dd328c7f9a8cb4793bfe000e0f15",
-        "affectsGlobalScope": false
+        "version": "805ff1678a02dc53be4a03d8ccf5d2790b231c12e758f2da13acec29f159e691",
+        "signature": "805ff1678a02dc53be4a03d8ccf5d2790b231c12e758f2da13acec29f159e691"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts": {
         "version": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe",
-        "signature": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe",
-        "affectsGlobalScope": false
+        "signature": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts": {
         "version": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b",
-        "signature": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b",
-        "affectsGlobalScope": false
+        "signature": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts": {
-        "version": "3af538d08533582416477eef974f5a20c2f9f7983f4b308b52c6af06d1978871",
-        "signature": "3af538d08533582416477eef974f5a20c2f9f7983f4b308b52c6af06d1978871",
-        "affectsGlobalScope": false
+        "version": "c77ce0aef3156b8b1e15b4633d3afb3c648fa0c5e5d26ad5f007ac2c8e58ce26",
+        "signature": "c77ce0aef3156b8b1e15b4633d3afb3c648fa0c5e5d26ad5f007ac2c8e58ce26"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts": {
-        "version": "a85bc9cbb84355005dfeb5bfb59b106f18508f291eba228b2189660315132a12",
-        "signature": "a85bc9cbb84355005dfeb5bfb59b106f18508f291eba228b2189660315132a12",
-        "affectsGlobalScope": false
+        "version": "2d3ef26d36ee7eac277c679f5761e0e7514662cb742e3178186558228443e879",
+        "signature": "2d3ef26d36ee7eac277c679f5761e0e7514662cb742e3178186558228443e879"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts": {
         "version": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322",
-        "signature": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322",
-        "affectsGlobalScope": false
+        "signature": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts": {
-        "version": "b04a11d30e0b9a6acb05a6527ca43d80f6c18b5195065a8c8114c643345ed0cb",
-        "signature": "b04a11d30e0b9a6acb05a6527ca43d80f6c18b5195065a8c8114c643345ed0cb",
-        "affectsGlobalScope": false
+        "version": "c510161504e41bea4291263f6405b00e4c4b939665a4199dbd24c4ba49795734",
+        "signature": "c510161504e41bea4291263f6405b00e4c4b939665a4199dbd24c4ba49795734"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts": {
-        "version": "2923fa12587452666fef06ed5f8ab0a90b9ecc3e543cc0291e3c20fca8a6a2dc",
-        "signature": "2923fa12587452666fef06ed5f8ab0a90b9ecc3e543cc0291e3c20fca8a6a2dc",
-        "affectsGlobalScope": false
+        "version": "e119b27b8657e87d4c368bdea4a770f6e08c83e1e393935fa71b1d9a1365b30b",
+        "signature": "e119b27b8657e87d4c368bdea4a770f6e08c83e1e393935fa71b1d9a1365b30b"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts": {
         "version": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc",
-        "signature": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc",
-        "affectsGlobalScope": false
+        "signature": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts": {
         "version": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11",
-        "signature": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11",
-        "affectsGlobalScope": false
+        "signature": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts": {
         "version": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1",
-        "signature": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1",
-        "affectsGlobalScope": false
+        "signature": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts": {
-        "version": "28802cbb3c09d398d575be1a2243557865cff83ae9f3a917a2d9cd333ccc088c",
-        "signature": "28802cbb3c09d398d575be1a2243557865cff83ae9f3a917a2d9cd333ccc088c",
-        "affectsGlobalScope": false
+        "version": "b41d04297f6825dd882b69f00959d43897b5a2f1039c930bd566cfb48eaa5df2",
+        "signature": "b41d04297f6825dd882b69f00959d43897b5a2f1039c930bd566cfb48eaa5df2"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts": {
         "version": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1",
-        "signature": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1",
-        "affectsGlobalScope": false
+        "signature": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts": {
-        "version": "8e2233d042ea108d00f33f66eb90563072b8e1dd6908a9242ad35efd4a633cfd",
-        "signature": "8e2233d042ea108d00f33f66eb90563072b8e1dd6908a9242ad35efd4a633cfd",
-        "affectsGlobalScope": false
+        "version": "91a3351510446075329a35e2123788f905a69b3f838abad5442a8b968d258d21",
+        "signature": "91a3351510446075329a35e2123788f905a69b3f838abad5442a8b968d258d21"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts": {
-        "version": "e66fd216d350c8deac2f9fc329c19c4e62293f6cab86a9ffa792abfcd7e84e90",
-        "signature": "e66fd216d350c8deac2f9fc329c19c4e62293f6cab86a9ffa792abfcd7e84e90",
-        "affectsGlobalScope": false
+        "version": "5c4ccaf0e6870a8d458aa637d4c8fc4cf21747f21f6963670635c6cc6edc4e22",
+        "signature": "5c4ccaf0e6870a8d458aa637d4c8fc4cf21747f21f6963670635c6cc6edc4e22"
       },
       "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts": {
         "version": "45764e880cd0158b4a1692c38670441b7d60ddfe6f8835641ca9bfceb5f78b9e",
-        "signature": "45764e880cd0158b4a1692c38670441b7d60ddfe6f8835641ca9bfceb5f78b9e",
-        "affectsGlobalScope": false
+        "signature": "45764e880cd0158b4a1692c38670441b7d60ddfe6f8835641ca9bfceb5f78b9e"
       },
       "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts": {
         "version": "30b5e83c2c380e084df3b84fcf910e70f43abfe11448875356cd38e7a3bbf7cd",
-        "signature": "30b5e83c2c380e084df3b84fcf910e70f43abfe11448875356cd38e7a3bbf7cd",
-        "affectsGlobalScope": false
+        "signature": "30b5e83c2c380e084df3b84fcf910e70f43abfe11448875356cd38e7a3bbf7cd"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts": {
-        "version": "71dee7372e749bf96df66de3d2231e4efb6c3965c01f1452326f41211d704b6b",
-        "signature": "71dee7372e749bf96df66de3d2231e4efb6c3965c01f1452326f41211d704b6b",
-        "affectsGlobalScope": false
+        "version": "866eb7ec572ba83cf0ef4f6ad2017be77b831afe2354e8c073afc1fbd8ce8fee",
+        "signature": "866eb7ec572ba83cf0ef4f6ad2017be77b831afe2354e8c073afc1fbd8ce8fee"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts": {
-        "version": "bd1bb89e16763711c3afdb4fc689e2fa9277a1a31e7fb01d813d2db7ca43636d",
-        "signature": "bd1bb89e16763711c3afdb4fc689e2fa9277a1a31e7fb01d813d2db7ca43636d",
-        "affectsGlobalScope": false
+        "version": "d0d683bd9f2b172c6bcafeff6205e747bd546ad1fe4b865c4d6342362d24ddf6",
+        "signature": "d0d683bd9f2b172c6bcafeff6205e747bd546ad1fe4b865c4d6342362d24ddf6"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts": {
-        "version": "f76c24e0612f9cafc3ef5b2d091a2afc8ee8fe0b12d1785fa0c920a77e435244",
-        "signature": "f76c24e0612f9cafc3ef5b2d091a2afc8ee8fe0b12d1785fa0c920a77e435244",
-        "affectsGlobalScope": false
+        "version": "d8f3ca2ceadb316ebf9f55b0fa1366d0ce44c768238f6e5369e05987ca0ce6f1",
+        "signature": "d8f3ca2ceadb316ebf9f55b0fa1366d0ce44c768238f6e5369e05987ca0ce6f1"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts": {
-        "version": "88de9a9c98584364f427af57e91b6ecb9c1a375b15a19120997754e6c7d33919",
-        "signature": "88de9a9c98584364f427af57e91b6ecb9c1a375b15a19120997754e6c7d33919",
-        "affectsGlobalScope": false
+        "version": "496b87c1158f9475e5216e01583f5bb1b98f6323f6ab7a899898d624a874e585",
+        "signature": "496b87c1158f9475e5216e01583f5bb1b98f6323f6ab7a899898d624a874e585"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts": {
         "version": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88",
-        "signature": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88",
-        "affectsGlobalScope": false
+        "signature": "bd2ab07f4d3e1f9f541383e8ef2c61658344348181d3020f6c663ee042375c88"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts": {
         "version": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6",
-        "signature": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6",
-        "affectsGlobalScope": false
+        "signature": "f1e1e68cbe048ee1112f2929c7d68d53d4ad86dacd6e45bafaa5c5801047b7c6"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts": {
         "version": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64",
-        "signature": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64",
-        "affectsGlobalScope": false
+        "signature": "10e0b60f4e14b244bd145f694f0690d8b9f26c8c7a755743afabdd992935fc64"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts": {
         "version": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420",
-        "signature": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420",
-        "affectsGlobalScope": false
+        "signature": "6d02c401f67c24d2a7d3714ae5ce6be75d0f6a9f25a9ef3bde0c00ee651fd420"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts": {
         "version": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b",
-        "signature": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b",
-        "affectsGlobalScope": false
+        "signature": "5873abbf948918e64a1d648d7b60cdfd2eb9e9902d6d1c580876218824ff689b"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts": {
         "version": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558",
-        "signature": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558",
-        "affectsGlobalScope": false
+        "signature": "843fbd11bfa2082344b49c439a938f6f0cb3a185eb68acfde43f672b093b8558"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts": {
         "version": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8",
-        "signature": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8",
-        "affectsGlobalScope": false
-      },
-      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": {
-        "version": "27f2e8f96442bee1380a2b36ee79fcaa03965463eedca581aa17a553b08091ef",
-        "signature": "27f2e8f96442bee1380a2b36ee79fcaa03965463eedca581aa17a553b08091ef",
-        "affectsGlobalScope": false
+        "signature": "3ceb238111cbea7ba1b9b25a4833c5a0432637610f3245c6b1cf5804acfcfbb8"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts": {
-        "version": "b2cabd671bc6ac4fe56661911667354ddb1a63e80ee21233f92580e917f6901a",
-        "signature": "b2cabd671bc6ac4fe56661911667354ddb1a63e80ee21233f92580e917f6901a",
-        "affectsGlobalScope": false
+        "version": "5fd0825b158c7aa174fa18a3bf032d189825da2e4f507b06aa6d0575b59628d5",
+        "signature": "5fd0825b158c7aa174fa18a3bf032d189825da2e4f507b06aa6d0575b59628d5"
+      },
+      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": {
+        "version": "bfee6627661665286f81224b067147803ddf7a9f5a00bdd4b9927860dd03159e",
+        "signature": "bfee6627661665286f81224b067147803ddf7a9f5a00bdd4b9927860dd03159e"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts": {
-        "version": "c83307af3022a3718c11180a153136010e22dd328c7f9a8cb4793bfe000e0f15",
-        "signature": "c83307af3022a3718c11180a153136010e22dd328c7f9a8cb4793bfe000e0f15",
-        "affectsGlobalScope": false
+        "version": "805ff1678a02dc53be4a03d8ccf5d2790b231c12e758f2da13acec29f159e691",
+        "signature": "805ff1678a02dc53be4a03d8ccf5d2790b231c12e758f2da13acec29f159e691"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts": {
         "version": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe",
-        "signature": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe",
-        "affectsGlobalScope": false
+        "signature": "75eaa6171bc3ce74f87a9fea83c35e5d2bfda3518eec74466cf3551fadded8fe"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts": {
         "version": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b",
-        "signature": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b",
-        "affectsGlobalScope": false
+        "signature": "415e515ed4588ed18d93fd9aba9876fc11f537a96461d2e47c0bfe2c400ecd3b"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts": {
-        "version": "3af538d08533582416477eef974f5a20c2f9f7983f4b308b52c6af06d1978871",
-        "signature": "3af538d08533582416477eef974f5a20c2f9f7983f4b308b52c6af06d1978871",
-        "affectsGlobalScope": false
+        "version": "c77ce0aef3156b8b1e15b4633d3afb3c648fa0c5e5d26ad5f007ac2c8e58ce26",
+        "signature": "c77ce0aef3156b8b1e15b4633d3afb3c648fa0c5e5d26ad5f007ac2c8e58ce26"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts": {
-        "version": "a85bc9cbb84355005dfeb5bfb59b106f18508f291eba228b2189660315132a12",
-        "signature": "a85bc9cbb84355005dfeb5bfb59b106f18508f291eba228b2189660315132a12",
-        "affectsGlobalScope": false
+        "version": "2d3ef26d36ee7eac277c679f5761e0e7514662cb742e3178186558228443e879",
+        "signature": "2d3ef26d36ee7eac277c679f5761e0e7514662cb742e3178186558228443e879"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts": {
         "version": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322",
-        "signature": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322",
-        "affectsGlobalScope": false
+        "signature": "47117799e8c69dc9aeb5ea8bc3e293213bc3d330bf4ebcc63d6d11ae312cf322"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts": {
-        "version": "b04a11d30e0b9a6acb05a6527ca43d80f6c18b5195065a8c8114c643345ed0cb",
-        "signature": "b04a11d30e0b9a6acb05a6527ca43d80f6c18b5195065a8c8114c643345ed0cb",
-        "affectsGlobalScope": false
+        "version": "c510161504e41bea4291263f6405b00e4c4b939665a4199dbd24c4ba49795734",
+        "signature": "c510161504e41bea4291263f6405b00e4c4b939665a4199dbd24c4ba49795734"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts": {
-        "version": "2923fa12587452666fef06ed5f8ab0a90b9ecc3e543cc0291e3c20fca8a6a2dc",
-        "signature": "2923fa12587452666fef06ed5f8ab0a90b9ecc3e543cc0291e3c20fca8a6a2dc",
-        "affectsGlobalScope": false
+        "version": "e119b27b8657e87d4c368bdea4a770f6e08c83e1e393935fa71b1d9a1365b30b",
+        "signature": "e119b27b8657e87d4c368bdea4a770f6e08c83e1e393935fa71b1d9a1365b30b"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts": {
         "version": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc",
-        "signature": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc",
-        "affectsGlobalScope": false
+        "signature": "9e49128604fb19c20325ef6782df05dff852fc1244d4c2d72084de953bb9c8cc"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts": {
         "version": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11",
-        "signature": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11",
-        "affectsGlobalScope": false
+        "signature": "6646d1446d9958fc1fef81b60208835665d44df47880fc1264a7f721329aed11"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/configuredom4.d.ts": {
         "version": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "affectsGlobalScope": false
+        "signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts": {
         "version": "9e3c4f9cbf53096fcdc9c514a3e6a5e406cd35344a7d08322a3df65a1815aa57",
-        "signature": "9e3c4f9cbf53096fcdc9c514a3e6a5e406cd35344a7d08322a3df65a1815aa57",
-        "affectsGlobalScope": false
+        "signature": "9e3c4f9cbf53096fcdc9c514a3e6a5e406cd35344a7d08322a3df65a1815aa57"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts": {
         "version": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1",
-        "signature": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1",
-        "affectsGlobalScope": false
+        "signature": "9c73dc4f3dbd7e04a04c2cf492e9f6847686c582646144ed5345357205f6fab1"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts": {
-        "version": "733cb18b5ab937b85d346cf35c53881aed027bedc6c6449a75ec813803293da2",
-        "signature": "733cb18b5ab937b85d346cf35c53881aed027bedc6c6449a75ec813803293da2",
-        "affectsGlobalScope": false
+        "version": "d4c86a0ecea207ccae31431d3e4275a5103b3339a2a82f74a1bcc9b43218c79f",
+        "signature": "d4c86a0ecea207ccae31431d3e4275a5103b3339a2a82f74a1bcc9b43218c79f"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts": {
         "version": "91ced0a26f6193e4b21e3e5ead24dcdfa10d370d89595e48a726c96b26c0efbe",
-        "signature": "91ced0a26f6193e4b21e3e5ead24dcdfa10d370d89595e48a726c96b26c0efbe",
-        "affectsGlobalScope": false
+        "signature": "91ced0a26f6193e4b21e3e5ead24dcdfa10d370d89595e48a726c96b26c0efbe"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts": {
         "version": "bbb772cd5a75a4fd8ad3b989f8f72233e4a01b2ec7740273e1aa3ad689f2924b",
-        "signature": "bbb772cd5a75a4fd8ad3b989f8f72233e4a01b2ec7740273e1aa3ad689f2924b",
-        "affectsGlobalScope": false
+        "signature": "bbb772cd5a75a4fd8ad3b989f8f72233e4a01b2ec7740273e1aa3ad689f2924b"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts": {
-        "version": "ebe3fc7c1865ed962737b3e8a869ca280891f037209a434d085eac45e1bd2c7b",
-        "signature": "ebe3fc7c1865ed962737b3e8a869ca280891f037209a434d085eac45e1bd2c7b",
-        "affectsGlobalScope": false
+        "version": "d04a99b103297d65518456797de820453757d53a9d2d869068ca70e6d53d1148",
+        "signature": "d04a99b103297d65518456797de820453757d53a9d2d869068ca70e6d53d1148"
       },
       "./node_modules/popper.js/index.d.ts": {
         "version": "1873db8f2261ba4f248bde3e5bb4c79b1fdc990315054e9604fce8f41ddd1587",
-        "signature": "1873db8f2261ba4f248bde3e5bb4c79b1fdc990315054e9604fce8f41ddd1587",
-        "affectsGlobalScope": false
+        "signature": "1873db8f2261ba4f248bde3e5bb4c79b1fdc990315054e9604fce8f41ddd1587"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts": {
-        "version": "cb1f95d9d7d5764794c629b86d74df95b0d32658989deb3a2807a1992d28612c",
-        "signature": "cb1f95d9d7d5764794c629b86d74df95b0d32658989deb3a2807a1992d28612c",
-        "affectsGlobalScope": false
+        "version": "f31a3b81a6d53e9f7edce5d2712d51ab88c4dfe4991fd6051994f4acea6bc1b1",
+        "signature": "f31a3b81a6d53e9f7edce5d2712d51ab88c4dfe4991fd6051994f4acea6bc1b1"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts": {
-        "version": "c582c52cff969d240f65a194c8ff7543f4a5758b09febd8fe8e31a4b08751456",
-        "signature": "c582c52cff969d240f65a194c8ff7543f4a5758b09febd8fe8e31a4b08751456",
-        "affectsGlobalScope": false
+        "version": "114144e4287433a7e19399219cf44fff214e82e159a5adc8fafa89dc3a00a80b",
+        "signature": "114144e4287433a7e19399219cf44fff214e82e159a5adc8fafa89dc3a00a80b"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts": {
         "version": "eb3caeeabe7f2cbd53daa0bcd006198ca5b1fb302125198bdf6118c55d80a03c",
-        "signature": "eb3caeeabe7f2cbd53daa0bcd006198ca5b1fb302125198bdf6118c55d80a03c",
-        "affectsGlobalScope": false
+        "signature": "eb3caeeabe7f2cbd53daa0bcd006198ca5b1fb302125198bdf6118c55d80a03c"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts": {
-        "version": "fbfb30bdef2c6ae2c8aa1c0f28d73f4d020a28f8a9ec655145469fb8fdf1011c",
-        "signature": "fbfb30bdef2c6ae2c8aa1c0f28d73f4d020a28f8a9ec655145469fb8fdf1011c",
-        "affectsGlobalScope": false
+        "version": "3a701ed307a83722944120282dffe95df88bedde0033928fe7cefa18e4683886",
+        "signature": "3a701ed307a83722944120282dffe95df88bedde0033928fe7cefa18e4683886"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts": {
         "version": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1",
-        "signature": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1",
-        "affectsGlobalScope": false
+        "signature": "b37a2bf5d9ad82df4a9e063b504eb8e809bce2d57ca669bf0e3dd5d63a3105a1"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts": {
         "version": "868d9028f5f0f6a488259783eb06766479562c98998d36b6c88311ea67808a24",
-        "signature": "868d9028f5f0f6a488259783eb06766479562c98998d36b6c88311ea67808a24",
-        "affectsGlobalScope": false
+        "signature": "868d9028f5f0f6a488259783eb06766479562c98998d36b6c88311ea67808a24"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts": {
         "version": "79067e3fa65a5203a02a81da55a2edc029f0e253d7762c2883c5e48de5c8b4c3",
-        "signature": "79067e3fa65a5203a02a81da55a2edc029f0e253d7762c2883c5e48de5c8b4c3",
-        "affectsGlobalScope": false
+        "signature": "79067e3fa65a5203a02a81da55a2edc029f0e253d7762c2883c5e48de5c8b4c3"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts": {
         "version": "2b15091f8db5f4b4ba0b0d3686a53da364abf539937e7cf23537b1171674e23d",
-        "signature": "2b15091f8db5f4b4ba0b0d3686a53da364abf539937e7cf23537b1171674e23d",
-        "affectsGlobalScope": false
+        "signature": "2b15091f8db5f4b4ba0b0d3686a53da364abf539937e7cf23537b1171674e23d"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts": {
-        "version": "8e2233d042ea108d00f33f66eb90563072b8e1dd6908a9242ad35efd4a633cfd",
-        "signature": "8e2233d042ea108d00f33f66eb90563072b8e1dd6908a9242ad35efd4a633cfd",
-        "affectsGlobalScope": false
+        "version": "91a3351510446075329a35e2123788f905a69b3f838abad5442a8b968d258d21",
+        "signature": "91a3351510446075329a35e2123788f905a69b3f838abad5442a8b968d258d21"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts": {
-        "version": "42cf878734174b11746b17c5a2e8e173281896c4d82e90c6fc7d52dbbde6ba5b",
-        "signature": "42cf878734174b11746b17c5a2e8e173281896c4d82e90c6fc7d52dbbde6ba5b",
-        "affectsGlobalScope": false
+        "version": "3fa1579bb35888a32fff6e91aeece5c605cd9aa8e15502802a4a1d7c141cf27f",
+        "signature": "3fa1579bb35888a32fff6e91aeece5c605cd9aa8e15502802a4a1d7c141cf27f"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts": {
-        "version": "4800280eda0acf86b6813d818278f2459ad44727521b42a025a4d48471eec38d",
-        "signature": "4800280eda0acf86b6813d818278f2459ad44727521b42a025a4d48471eec38d",
-        "affectsGlobalScope": false
+        "version": "c86d755e8376e263f71c2f926e2765274bc8526f3ec81a202ac08c18f2047905",
+        "signature": "c86d755e8376e263f71c2f926e2765274bc8526f3ec81a202ac08c18f2047905"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts": {
-        "version": "f9363bb824e8b46800aef7103358f0ae351387250ba3520197b067605c26c427",
-        "signature": "f9363bb824e8b46800aef7103358f0ae351387250ba3520197b067605c26c427",
-        "affectsGlobalScope": false
+        "version": "f99853bdca119789baa5eb2106dc161e78a79086cb681537b49d05d405a40980",
+        "signature": "f99853bdca119789baa5eb2106dc161e78a79086cb681537b49d05d405a40980"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts": {
         "version": "092fc7f4245f32afd89a7c9fe46d7de7c0063e8208bba1c4105cf6821b213be8",
-        "signature": "092fc7f4245f32afd89a7c9fe46d7de7c0063e8208bba1c4105cf6821b213be8",
-        "affectsGlobalScope": false
+        "signature": "092fc7f4245f32afd89a7c9fe46d7de7c0063e8208bba1c4105cf6821b213be8"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts": {
-        "version": "1f3215b0d636b60c5dc30305a21b18d10e537af1394f458275273706953be1ab",
-        "signature": "1f3215b0d636b60c5dc30305a21b18d10e537af1394f458275273706953be1ab",
-        "affectsGlobalScope": false
+        "version": "5e85b5857c215eb695390136e29cb76fd07d87e9b5f809e71b6f190d90e97f03",
+        "signature": "5e85b5857c215eb695390136e29cb76fd07d87e9b5f809e71b6f190d90e97f03"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts": {
         "version": "0bdf38335209735e9c064688961a500116f040c714b35d340810e2eafc8007b3",
-        "signature": "0bdf38335209735e9c064688961a500116f040c714b35d340810e2eafc8007b3",
-        "affectsGlobalScope": false
+        "signature": "0bdf38335209735e9c064688961a500116f040c714b35d340810e2eafc8007b3"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts": {
-        "version": "78aae31fff34eaf0da69fa0a7dcf0a4c573f35ba0c87eb7a0d8f7c894bd4ffb2",
-        "signature": "78aae31fff34eaf0da69fa0a7dcf0a4c573f35ba0c87eb7a0d8f7c894bd4ffb2",
-        "affectsGlobalScope": false
+        "version": "c3af7730c67a16d8e4a16c2ea27fdb8487433070b0c47b02fea9be442c32e3b5",
+        "signature": "c3af7730c67a16d8e4a16c2ea27fdb8487433070b0c47b02fea9be442c32e3b5"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts": {
         "version": "63e04e0156110d304d4908b1ed2b1fef7b1384518f57edbbf10c8610b1a31135",
-        "signature": "63e04e0156110d304d4908b1ed2b1fef7b1384518f57edbbf10c8610b1a31135",
-        "affectsGlobalScope": false
+        "signature": "63e04e0156110d304d4908b1ed2b1fef7b1384518f57edbbf10c8610b1a31135"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts": {
         "version": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256",
-        "signature": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256",
-        "affectsGlobalScope": false
+        "signature": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts": {
         "version": "3f5474b348c1a990dd62597a3508ebba004b7825ed5b307d9c51cc8ccd26d808",
-        "signature": "3f5474b348c1a990dd62597a3508ebba004b7825ed5b307d9c51cc8ccd26d808",
-        "affectsGlobalScope": false
+        "signature": "3f5474b348c1a990dd62597a3508ebba004b7825ed5b307d9c51cc8ccd26d808"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts": {
         "version": "62ff7c4f0eb9367b9ccb9685c74444559eaf9e0d92ffcab4126af02729b42ba5",
-        "signature": "62ff7c4f0eb9367b9ccb9685c74444559eaf9e0d92ffcab4126af02729b42ba5",
-        "affectsGlobalScope": false
+        "signature": "62ff7c4f0eb9367b9ccb9685c74444559eaf9e0d92ffcab4126af02729b42ba5"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts": {
-        "version": "e66fd216d350c8deac2f9fc329c19c4e62293f6cab86a9ffa792abfcd7e84e90",
-        "signature": "e66fd216d350c8deac2f9fc329c19c4e62293f6cab86a9ffa792abfcd7e84e90",
-        "affectsGlobalScope": false
+        "version": "5c4ccaf0e6870a8d458aa637d4c8fc4cf21747f21f6963670635c6cc6edc4e22",
+        "signature": "5c4ccaf0e6870a8d458aa637d4c8fc4cf21747f21f6963670635c6cc6edc4e22"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts": {
-        "version": "67413385a3dea5ff18923c5be9d348be0eaee9de57c74b5a02e41d06a36afcfc",
-        "signature": "67413385a3dea5ff18923c5be9d348be0eaee9de57c74b5a02e41d06a36afcfc",
-        "affectsGlobalScope": false
+        "version": "f9147fbf4c60515ae1f05795e02acf74c7d2d5b04382a9cfff89eba62fbcc45a",
+        "signature": "f9147fbf4c60515ae1f05795e02acf74c7d2d5b04382a9cfff89eba62fbcc45a"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts": {
-        "version": "05070e67388f203a05033918b4d2565b0e83e1d67a933f54e8a6f77d36298258",
-        "signature": "05070e67388f203a05033918b4d2565b0e83e1d67a933f54e8a6f77d36298258",
-        "affectsGlobalScope": false
+        "version": "95cc70c4d529719911fc464abb0cfab7deb1b210577a4e1fbc6d1805dd750ce4",
+        "signature": "95cc70c4d529719911fc464abb0cfab7deb1b210577a4e1fbc6d1805dd750ce4"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts": {
-        "version": "5cda831712c82811643c0de674d2fce7b17f1c61c67c1081e40c0135fba90b0a",
-        "signature": "5cda831712c82811643c0de674d2fce7b17f1c61c67c1081e40c0135fba90b0a",
-        "affectsGlobalScope": false
+        "version": "27530ac894c96f3c4ee380d2f0ee8d4fb4317358dbf5bfe278c2a8ceaa8c32e0",
+        "signature": "27530ac894c96f3c4ee380d2f0ee8d4fb4317358dbf5bfe278c2a8ceaa8c32e0"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts": {
-        "version": "8865e8a495b7543e0a0d919df6808a2fa5da1dcae9dcc682593c745c49e1ba87",
-        "signature": "8865e8a495b7543e0a0d919df6808a2fa5da1dcae9dcc682593c745c49e1ba87",
-        "affectsGlobalScope": false
+        "version": "3f39474d72edcd1979d78580b91d755d81386fe7222b831e16fb886ae2299831",
+        "signature": "3f39474d72edcd1979d78580b91d755d81386fe7222b831e16fb886ae2299831"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts": {
-        "version": "c9c2e5f7c4726703a6772eab6fff9da12e3f5a8d7440e4865a599c3e6599ecfd",
-        "signature": "c9c2e5f7c4726703a6772eab6fff9da12e3f5a8d7440e4865a599c3e6599ecfd",
-        "affectsGlobalScope": false
+        "version": "3ef3d45dda5ffe1fa48708654f9ae1a6c94fe8ef2cb25358767708144f3aa036",
+        "signature": "3ef3d45dda5ffe1fa48708654f9ae1a6c94fe8ef2cb25358767708144f3aa036"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts": {
-        "version": "d9f22bbc6af8625368d13a82a7486fb011fee7d28bb74a882c87f0973c7768fb",
-        "signature": "d9f22bbc6af8625368d13a82a7486fb011fee7d28bb74a882c87f0973c7768fb",
-        "affectsGlobalScope": false
+        "version": "c17b056a4ed61180b8c0f98cceaad52411ec344c197c3ac723ffd093b2679842",
+        "signature": "c17b056a4ed61180b8c0f98cceaad52411ec344c197c3ac723ffd093b2679842"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts": {
         "version": "af878249a46ff427c2fc5a09f09290c17c9f8c584c2ee73372841677d57ec605",
-        "signature": "af878249a46ff427c2fc5a09f09290c17c9f8c584c2ee73372841677d57ec605",
-        "affectsGlobalScope": false
+        "signature": "af878249a46ff427c2fc5a09f09290c17c9f8c584c2ee73372841677d57ec605"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts": {
-        "version": "568e9cbcbf01c6dec3d57b1b2b18b2baf69e3a2c0a15242b4c516c98e149ce61",
-        "signature": "568e9cbcbf01c6dec3d57b1b2b18b2baf69e3a2c0a15242b4c516c98e149ce61",
-        "affectsGlobalScope": false
+        "version": "3a1113fc275cae51ff74af07d8544170106117a5545a8381d05756bde52126be",
+        "signature": "3a1113fc275cae51ff74af07d8544170106117a5545a8381d05756bde52126be"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts": {
-        "version": "13255c22c65e85c3af96bcc86010fc9bc7d422cbf6e6ef9e8898484a49f6f78f",
-        "signature": "13255c22c65e85c3af96bcc86010fc9bc7d422cbf6e6ef9e8898484a49f6f78f",
-        "affectsGlobalScope": false
+        "version": "cd165e960eb4ba4f65db03de78bc5d6d1f025f56b51d51fa108e96660e7686f9",
+        "signature": "cd165e960eb4ba4f65db03de78bc5d6d1f025f56b51d51fa108e96660e7686f9"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts": {
         "version": "8de06d65241be60c572eaad1a8f5c841b3b025e7a08d7bda090296d5e117b248",
-        "signature": "8de06d65241be60c572eaad1a8f5c841b3b025e7a08d7bda090296d5e117b248",
-        "affectsGlobalScope": false
+        "signature": "8de06d65241be60c572eaad1a8f5c841b3b025e7a08d7bda090296d5e117b248"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts": {
-        "version": "935c448cb9a6538b1590fa3802d15528186c0a2dc8644ebc0b9260ce4c6ec87f",
-        "signature": "935c448cb9a6538b1590fa3802d15528186c0a2dc8644ebc0b9260ce4c6ec87f",
-        "affectsGlobalScope": false
+        "version": "25ff1b9cce87802468e368a8f5cfa1fc6b441ed7f042e74f4cf0774970a55d78",
+        "signature": "25ff1b9cce87802468e368a8f5cfa1fc6b441ed7f042e74f4cf0774970a55d78"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts": {
         "version": "d442718e27311698feab5e56acc9cd7f9f1d7901f909d29577c66409aa36816e",
-        "signature": "d442718e27311698feab5e56acc9cd7f9f1d7901f909d29577c66409aa36816e",
-        "affectsGlobalScope": false
+        "signature": "d442718e27311698feab5e56acc9cd7f9f1d7901f909d29577c66409aa36816e"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts": {
-        "version": "b7a8b15ef760a34c4540907189282721fdf9156d2a2b3f7d15eecc1e34d0e950",
-        "signature": "b7a8b15ef760a34c4540907189282721fdf9156d2a2b3f7d15eecc1e34d0e950",
-        "affectsGlobalScope": false
+        "version": "7fa4c3982c0a0698a61db01e1171c9813606c4843420340af6f9777ae720b430",
+        "signature": "7fa4c3982c0a0698a61db01e1171c9813606c4843420340af6f9777ae720b430"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts": {
         "version": "12c2e8adc7de9f8ea260c55fedcacd26bb6dda520d4294b6550dab5a962f0f39",
-        "signature": "12c2e8adc7de9f8ea260c55fedcacd26bb6dda520d4294b6550dab5a962f0f39",
-        "affectsGlobalScope": false
+        "signature": "12c2e8adc7de9f8ea260c55fedcacd26bb6dda520d4294b6550dab5a962f0f39"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts": {
         "version": "cb578d9ba6614469f18b85155a91c4916fbb1709d943a6a64e06f3b2546a3717",
-        "signature": "cb578d9ba6614469f18b85155a91c4916fbb1709d943a6a64e06f3b2546a3717",
-        "affectsGlobalScope": false
+        "signature": "cb578d9ba6614469f18b85155a91c4916fbb1709d943a6a64e06f3b2546a3717"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts": {
         "version": "29e4e1ac6b5601d38de4dc20ad8fabb8e899d9f525405d234a5f60df9fc7cb5f",
-        "signature": "29e4e1ac6b5601d38de4dc20ad8fabb8e899d9f525405d234a5f60df9fc7cb5f",
-        "affectsGlobalScope": false
+        "signature": "29e4e1ac6b5601d38de4dc20ad8fabb8e899d9f525405d234a5f60df9fc7cb5f"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts": {
         "version": "4043acb1d6c7c79a41a619cc7c4946a4d45fd16218bb39c1340a0b85468e8fb2",
-        "signature": "4043acb1d6c7c79a41a619cc7c4946a4d45fd16218bb39c1340a0b85468e8fb2",
-        "affectsGlobalScope": false
+        "signature": "4043acb1d6c7c79a41a619cc7c4946a4d45fd16218bb39c1340a0b85468e8fb2"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts": {
         "version": "199fb38b462aef3170790638fadb0d07f81df196aff8fb79ffb9caab90dda33e",
-        "signature": "199fb38b462aef3170790638fadb0d07f81df196aff8fb79ffb9caab90dda33e",
-        "affectsGlobalScope": false
+        "signature": "199fb38b462aef3170790638fadb0d07f81df196aff8fb79ffb9caab90dda33e"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts": {
         "version": "d4ed3fd72fecdf8a4d608992236627dd660d0815557e5b3242b7c2120bf7939a",
-        "signature": "d4ed3fd72fecdf8a4d608992236627dd660d0815557e5b3242b7c2120bf7939a",
-        "affectsGlobalScope": false
+        "signature": "d4ed3fd72fecdf8a4d608992236627dd660d0815557e5b3242b7c2120bf7939a"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts": {
         "version": "7c28e8b7697e425d0fb48327d5c0035338b33a7a411407cc10969575e0cddc62",
-        "signature": "7c28e8b7697e425d0fb48327d5c0035338b33a7a411407cc10969575e0cddc62",
-        "affectsGlobalScope": false
+        "signature": "7c28e8b7697e425d0fb48327d5c0035338b33a7a411407cc10969575e0cddc62"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts": {
         "version": "76bc136e8aae33abe7696585c97efb26256e2b1f003fe727085e495098740a1d",
-        "signature": "76bc136e8aae33abe7696585c97efb26256e2b1f003fe727085e495098740a1d",
-        "affectsGlobalScope": false
+        "signature": "76bc136e8aae33abe7696585c97efb26256e2b1f003fe727085e495098740a1d"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts": {
         "version": "83e2832757571c6fdb66656ca8babe1cb3c3c9b47be0723adf39b41bbf4c9d4a",
-        "signature": "83e2832757571c6fdb66656ca8babe1cb3c3c9b47be0723adf39b41bbf4c9d4a",
-        "affectsGlobalScope": false
+        "signature": "83e2832757571c6fdb66656ca8babe1cb3c3c9b47be0723adf39b41bbf4c9d4a"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts": {
-        "version": "9e902b726adc803de9e1dd0408d166d5e5a1da928bb71ed15dd6991108a1ac41",
-        "signature": "9e902b726adc803de9e1dd0408d166d5e5a1da928bb71ed15dd6991108a1ac41",
-        "affectsGlobalScope": false
+        "version": "515780e76a01729f2b6be340fcf53cd5022f57c841dd84dcc3ccc40b2a630929",
+        "signature": "515780e76a01729f2b6be340fcf53cd5022f57c841dd84dcc3ccc40b2a630929"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts": {
-        "version": "55221b6a6bc9569799f40ee544bb130087a8e3e38b78b3929708a20c84c5c0de",
-        "signature": "55221b6a6bc9569799f40ee544bb130087a8e3e38b78b3929708a20c84c5c0de",
-        "affectsGlobalScope": false
+        "version": "87d10a151f7b52b1131df33b492811430ba9d2b762761cc77e46d1639bf34d7d",
+        "signature": "87d10a151f7b52b1131df33b492811430ba9d2b762761cc77e46d1639bf34d7d"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts": {
         "version": "a220410fc48966b454db6958d09782ee785e9f587185f642dbaa761527c156ad",
-        "signature": "a220410fc48966b454db6958d09782ee785e9f587185f642dbaa761527c156ad",
-        "affectsGlobalScope": false
+        "signature": "a220410fc48966b454db6958d09782ee785e9f587185f642dbaa761527c156ad"
       },
       "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts": {
-        "version": "6783a8c01400604f5d6a571c917af1e3a28754f772223a60254d0043bfe2b3a2",
-        "signature": "6783a8c01400604f5d6a571c917af1e3a28754f772223a60254d0043bfe2b3a2",
-        "affectsGlobalScope": false
+        "version": "6af6177e515fd46648854e37fef518d482cc55fa35392c3cac1eefcbf4970b53",
+        "signature": "6af6177e515fd46648854e37fef518d482cc55fa35392c3cac1eefcbf4970b53"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts": {
-        "version": "994be8520296d9e5918bcff3199bd9f1d137cb167948083f63e73597074d54cd",
-        "signature": "994be8520296d9e5918bcff3199bd9f1d137cb167948083f63e73597074d54cd",
-        "affectsGlobalScope": false
+        "version": "06e9c17a476e3dc0c70ff5ff391f53f5bd37703fb9752fa2d430573c7bdca6ee",
+        "signature": "06e9c17a476e3dc0c70ff5ff391f53f5bd37703fb9752fa2d430573c7bdca6ee"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts": {
         "version": "2aa772b10e3180d0ccae006da7ec440f367b4209cececa7d8ebe467eb7f5cdd7",
-        "signature": "2aa772b10e3180d0ccae006da7ec440f367b4209cececa7d8ebe467eb7f5cdd7",
-        "affectsGlobalScope": false
+        "signature": "2aa772b10e3180d0ccae006da7ec440f367b4209cececa7d8ebe467eb7f5cdd7"
+      },
+      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts": {
+        "version": "76d5e91c944c990249e830165a33335f90630e1b02bd72624e38658c0d87c72d",
+        "signature": "76d5e91c944c990249e830165a33335f90630e1b02bd72624e38658c0d87c72d"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts": {
-        "version": "7444d0c9d788661d6978312a8b9c6579c4f5a6e86c01374c35465f09baca49ac",
-        "signature": "7444d0c9d788661d6978312a8b9c6579c4f5a6e86c01374c35465f09baca49ac",
-        "affectsGlobalScope": false
+        "version": "079e78144f9579bfca032d6bc31ff7fd597e57cbd2641cbddf8cbf121a154bbc",
+        "signature": "079e78144f9579bfca032d6bc31ff7fd597e57cbd2641cbddf8cbf121a154bbc"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts": {
         "version": "0d8fbdf8b41eb1ccff779e07c6e060bdfdd327d006032a71766b6d9fcd78dd84",
-        "signature": "0d8fbdf8b41eb1ccff779e07c6e060bdfdd327d006032a71766b6d9fcd78dd84",
-        "affectsGlobalScope": false
+        "signature": "0d8fbdf8b41eb1ccff779e07c6e060bdfdd327d006032a71766b6d9fcd78dd84"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts": {
-        "version": "78365b179d01e0327e6fc23ee247e37da6c69b4764b3da3308aedc1497c8a8bd",
-        "signature": "78365b179d01e0327e6fc23ee247e37da6c69b4764b3da3308aedc1497c8a8bd",
-        "affectsGlobalScope": false
+        "version": "0e6eb9b4be09c3c9ded5e5966b0711e155db53b324dd1f9cc97afed525f2abec",
+        "signature": "0e6eb9b4be09c3c9ded5e5966b0711e155db53b324dd1f9cc97afed525f2abec"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts": {
         "version": "ceb6ac9923d8e6f7e4b61eb0aceaddfcb94d8feabacddcff876d489b6d3b31dd",
-        "signature": "ceb6ac9923d8e6f7e4b61eb0aceaddfcb94d8feabacddcff876d489b6d3b31dd",
-        "affectsGlobalScope": false
+        "signature": "ceb6ac9923d8e6f7e4b61eb0aceaddfcb94d8feabacddcff876d489b6d3b31dd"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts": {
         "version": "0ed9fad677f6b4a0f14f44087d6abf64f8eb2bb66fa14da595af74dd285ddfc9",
-        "signature": "0ed9fad677f6b4a0f14f44087d6abf64f8eb2bb66fa14da595af74dd285ddfc9",
-        "affectsGlobalScope": false
+        "signature": "0ed9fad677f6b4a0f14f44087d6abf64f8eb2bb66fa14da595af74dd285ddfc9"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts": {
-        "version": "4eab85507fcdbcbca139b86d7c1fe9a368e6a23ea7f7b692afc551d5ae4d44b5",
-        "signature": "4eab85507fcdbcbca139b86d7c1fe9a368e6a23ea7f7b692afc551d5ae4d44b5",
-        "affectsGlobalScope": false
+        "version": "afc8c1abfad46be449042cf89b41376581502d9f7c0503e903f714a5c8d8c5f4",
+        "signature": "afc8c1abfad46be449042cf89b41376581502d9f7c0503e903f714a5c8d8c5f4"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts": {
-        "version": "eba14f816ec7250ec9c73c34e529595587cb39b8d5d12abf89d5410cab2519c5",
-        "signature": "eba14f816ec7250ec9c73c34e529595587cb39b8d5d12abf89d5410cab2519c5",
-        "affectsGlobalScope": false
+        "version": "26317e89dc8a7f32c91a274873c8219d4a008efa4dc0c4fc0b591a1d29d4aa71",
+        "signature": "26317e89dc8a7f32c91a274873c8219d4a008efa4dc0c4fc0b591a1d29d4aa71"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts": {
-        "version": "598abdd0ff84403ce82e486ae874e5f73a460bb14102896642d130102e838ded",
-        "signature": "598abdd0ff84403ce82e486ae874e5f73a460bb14102896642d130102e838ded",
-        "affectsGlobalScope": false
+        "version": "fc4118e1947b5d6c714b6cdceb310731da255b4e0735e1c749b04ccf1b299f12",
+        "signature": "fc4118e1947b5d6c714b6cdceb310731da255b4e0735e1c749b04ccf1b299f12"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts": {
-        "version": "024d368fef7707949a3a6cf3bfdbe5e95811ed0c9f35db4ac1f740d784d8ec1a",
-        "signature": "024d368fef7707949a3a6cf3bfdbe5e95811ed0c9f35db4ac1f740d784d8ec1a",
-        "affectsGlobalScope": false
+        "version": "1424a6a181909968145c90bd4ceb881f8d25af7366829a73c2b88d75e45fd30f",
+        "signature": "1424a6a181909968145c90bd4ceb881f8d25af7366829a73c2b88d75e45fd30f"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts": {
-        "version": "69730412bfce5d6c1ea4bbed91a23cf62bc1a917420b765421ffaef7d06edb4b",
-        "signature": "69730412bfce5d6c1ea4bbed91a23cf62bc1a917420b765421ffaef7d06edb4b",
-        "affectsGlobalScope": false
+        "version": "e7bc2614776631d8d90cbae4ddb6ba31b8961aab780177dd4bb3cdfb5eb9592f",
+        "signature": "e7bc2614776631d8d90cbae4ddb6ba31b8961aab780177dd4bb3cdfb5eb9592f"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts": {
         "version": "2ea15263c71161af280a8ce99cda5fb8ee9ef4041168eb014bf7b188883bdb9e",
-        "signature": "2ea15263c71161af280a8ce99cda5fb8ee9ef4041168eb014bf7b188883bdb9e",
-        "affectsGlobalScope": false
+        "signature": "2ea15263c71161af280a8ce99cda5fb8ee9ef4041168eb014bf7b188883bdb9e"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts": {
-        "version": "3517e549ed61c349f919c5c38f5abc4abe2a2681cf01b12a628b1f92a4154810",
-        "signature": "3517e549ed61c349f919c5c38f5abc4abe2a2681cf01b12a628b1f92a4154810",
-        "affectsGlobalScope": false
+        "version": "64fe9d0a282722e3a502cdaa41d896de7773f6098fb367169741761406567e48",
+        "signature": "64fe9d0a282722e3a502cdaa41d896de7773f6098fb367169741761406567e48"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts": {
         "version": "20864513b3f3fb99dfc2625cdef988a1fe3b66a5f575324b91c74542cac3e8d3",
-        "signature": "20864513b3f3fb99dfc2625cdef988a1fe3b66a5f575324b91c74542cac3e8d3",
-        "affectsGlobalScope": false
+        "signature": "20864513b3f3fb99dfc2625cdef988a1fe3b66a5f575324b91c74542cac3e8d3"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts": {
-        "version": "5525196e8a0b04967c3e7eafad21569ef8c1cbc3a4af2eca91217144a7bd89f8",
-        "signature": "5525196e8a0b04967c3e7eafad21569ef8c1cbc3a4af2eca91217144a7bd89f8",
-        "affectsGlobalScope": false
+        "version": "8039ef5d8d4bc1a0e2a065808df0f876600e065e6c2954dbb441401892658ffc",
+        "signature": "8039ef5d8d4bc1a0e2a065808df0f876600e065e6c2954dbb441401892658ffc"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts": {
-        "version": "e9e06f3e724e9bfe60e2a252165ee10e2e7aee2058d894d9e23f01daf4473f0b",
-        "signature": "e9e06f3e724e9bfe60e2a252165ee10e2e7aee2058d894d9e23f01daf4473f0b",
-        "affectsGlobalScope": false
+        "version": "5a5db859356960b61b126072c381bdd948bb15c8a5a27615fde7339afac85e91",
+        "signature": "5a5db859356960b61b126072c381bdd948bb15c8a5a27615fde7339afac85e91"
       },
       "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts": {
-        "version": "cb62c84a8959c0d83accd135b394e5a5ec3f37a02fbe31f5a1f963b9f2e76b1e",
-        "signature": "cb62c84a8959c0d83accd135b394e5a5ec3f37a02fbe31f5a1f963b9f2e76b1e",
-        "affectsGlobalScope": false
+        "version": "49b22c1cdaf9c520391cd8c63e20bd1799909515c158f9069f9de2ab42a4c318",
+        "signature": "49b22c1cdaf9c520391cd8c63e20bd1799909515c158f9069f9de2ab42a4c318"
       },
       "./node_modules/@blueprintjs/core/lib/esm/index.d.ts": {
         "version": "fe8d41d1313b6153acd604ff261250a50f15056f6f574f414a0e38f443abcc3c",
-        "signature": "fe8d41d1313b6153acd604ff261250a50f15056f6f574f414a0e38f443abcc3c",
-        "affectsGlobalScope": false
+        "signature": "fe8d41d1313b6153acd604ff261250a50f15056f6f574f414a0e38f443abcc3c"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts": {
         "version": "90c50a5e678eb8160b1331b4c4d107f0cf1d2005c7d063cacf367283774d8791",
-        "signature": "90c50a5e678eb8160b1331b4c4d107f0cf1d2005c7d063cacf367283774d8791",
-        "affectsGlobalScope": false
+        "signature": "90c50a5e678eb8160b1331b4c4d107f0cf1d2005c7d063cacf367283774d8791"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts": {
         "version": "875b2375b7214808f47c525b583c22ff7e18864c5eb8ab6fb019e04d78d14653",
-        "signature": "875b2375b7214808f47c525b583c22ff7e18864c5eb8ab6fb019e04d78d14653",
-        "affectsGlobalScope": false
+        "signature": "875b2375b7214808f47c525b583c22ff7e18864c5eb8ab6fb019e04d78d14653"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts": {
-        "version": "3294fcc50db4606136723dd84fa86cf6f0e287a68f224468a5c36d732c8e43cb",
-        "signature": "3294fcc50db4606136723dd84fa86cf6f0e287a68f224468a5c36d732c8e43cb",
-        "affectsGlobalScope": false
+        "version": "c6064e4003192920088c4b39cacf2736d553714c207447247fba42658b403a7c",
+        "signature": "c6064e4003192920088c4b39cacf2736d553714c207447247fba42658b403a7c"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts": {
         "version": "360c80aa8c2bb72df69ac5c0ea32b1767d9a7e54294bf92c56d6fe0e6fd504cf",
-        "signature": "360c80aa8c2bb72df69ac5c0ea32b1767d9a7e54294bf92c56d6fe0e6fd504cf",
-        "affectsGlobalScope": false
+        "signature": "360c80aa8c2bb72df69ac5c0ea32b1767d9a7e54294bf92c56d6fe0e6fd504cf"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts": {
         "version": "27b3f549994f28c3b738ce39a929a8829ac9252653dc7d3ad8aa829f4d6cef7a",
-        "signature": "27b3f549994f28c3b738ce39a929a8829ac9252653dc7d3ad8aa829f4d6cef7a",
-        "affectsGlobalScope": false
+        "signature": "27b3f549994f28c3b738ce39a929a8829ac9252653dc7d3ad8aa829f4d6cef7a"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts": {
-        "version": "c523d2f40a523b8e852f60d6ca759cb3684ce61160a2911f58622438f92a919b",
-        "signature": "c523d2f40a523b8e852f60d6ca759cb3684ce61160a2911f58622438f92a919b",
-        "affectsGlobalScope": false
+        "version": "6beb3530541191ef4be8be5ce0470887d2fc514f54b27524695bef28cc6737c9",
+        "signature": "6beb3530541191ef4be8be5ce0470887d2fc514f54b27524695bef28cc6737c9"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts": {
         "version": "d7f35f1ff18f2bc33c0ec0234e12f47f8dcee29e76942689cabdfb4d19f3f4b0",
-        "signature": "d7f35f1ff18f2bc33c0ec0234e12f47f8dcee29e76942689cabdfb4d19f3f4b0",
-        "affectsGlobalScope": false
+        "signature": "d7f35f1ff18f2bc33c0ec0234e12f47f8dcee29e76942689cabdfb4d19f3f4b0"
       },
       "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts": {
-        "version": "f92a9fcd92fbf2840361fa8f6e101a99c9bda43ce07db7aa1d2430a7d514f168",
-        "signature": "f92a9fcd92fbf2840361fa8f6e101a99c9bda43ce07db7aa1d2430a7d514f168",
-        "affectsGlobalScope": false
+        "version": "df6d26956a8b3a214a1fea801614b50bcc4bd4a974e5db5fdc509b149cdf8d35",
+        "signature": "df6d26956a8b3a214a1fea801614b50bcc4bd4a974e5db5fdc509b149cdf8d35"
       },
       "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts": {
         "version": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256",
-        "signature": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256",
-        "affectsGlobalScope": false
+        "signature": "e1f42e03aa1bdff2861155f0607f40adb4506c3041a90ea78f10cbdb1ab6d256"
       },
       "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts": {
         "version": "1fdc44953936c5ef0406a8619a9592fd1a156e67c3feb9b9de9980bd1f3198c4",
-        "signature": "1fdc44953936c5ef0406a8619a9592fd1a156e67c3feb9b9de9980bd1f3198c4",
-        "affectsGlobalScope": false
+        "signature": "1fdc44953936c5ef0406a8619a9592fd1a156e67c3feb9b9de9980bd1f3198c4"
       },
       "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts": {
         "version": "f5f4eed847f0556304760c3beacdcb13a5e0410339897204eedc0b193d4b2d2b",
-        "signature": "f5f4eed847f0556304760c3beacdcb13a5e0410339897204eedc0b193d4b2d2b",
-        "affectsGlobalScope": false
+        "signature": "f5f4eed847f0556304760c3beacdcb13a5e0410339897204eedc0b193d4b2d2b"
       },
       "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts": {
         "version": "3bdcbc4d71a64f44368a69a02566a9c2357381e162f588eeb51ea610abb4766d",
-        "signature": "3bdcbc4d71a64f44368a69a02566a9c2357381e162f588eeb51ea610abb4766d",
-        "affectsGlobalScope": false
+        "signature": "3bdcbc4d71a64f44368a69a02566a9c2357381e162f588eeb51ea610abb4766d"
       },
       "./node_modules/@jupyterlab/ui-components/lib/index.d.ts": {
         "version": "f5bc18613bef94863772f383136e0b8eee89cb78a3d21e2fe61c95993037ee91",
-        "signature": "f5bc18613bef94863772f383136e0b8eee89cb78a3d21e2fe61c95993037ee91",
-        "affectsGlobalScope": false
+        "signature": "f5bc18613bef94863772f383136e0b8eee89cb78a3d21e2fe61c95993037ee91"
       },
       "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts": {
         "version": "dda124ecdfe719ccc4c67e4c626379953652ba7885cf965e8d1bc28891b16546",
-        "signature": "dda124ecdfe719ccc4c67e4c626379953652ba7885cf965e8d1bc28891b16546",
-        "affectsGlobalScope": false
+        "signature": "dda124ecdfe719ccc4c67e4c626379953652ba7885cf965e8d1bc28891b16546"
       },
       "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts": {
         "version": "4cf29ca63eb196de679cd3aa4ba46216e5f04d6fbd88a86e1364e3992fe88416",
-        "signature": "4cf29ca63eb196de679cd3aa4ba46216e5f04d6fbd88a86e1364e3992fe88416",
-        "affectsGlobalScope": false
+        "signature": "4cf29ca63eb196de679cd3aa4ba46216e5f04d6fbd88a86e1364e3992fe88416"
       },
       "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts": {
         "version": "7460b1c9180812599b0e4ad00aaf13fcf6f90e52e33ef88c2f7f60f37b1b88ba",
-        "signature": "7460b1c9180812599b0e4ad00aaf13fcf6f90e52e33ef88c2f7f60f37b1b88ba",
-        "affectsGlobalScope": false
+        "signature": "7460b1c9180812599b0e4ad00aaf13fcf6f90e52e33ef88c2f7f60f37b1b88ba"
       },
       "./node_modules/@jupyterlab/apputils/lib/printing.d.ts": {
         "version": "9149d7241d2c4078b7af32ec20f378000b74f49e91769a8b0cc26b6de4327bf3",
-        "signature": "9149d7241d2c4078b7af32ec20f378000b74f49e91769a8b0cc26b6de4327bf3",
-        "affectsGlobalScope": false
+        "signature": "9149d7241d2c4078b7af32ec20f378000b74f49e91769a8b0cc26b6de4327bf3"
       },
       "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts": {
         "version": "0857c64b513a11f69455a329681472099dce123090d320cc486a37651d6aa305",
-        "signature": "0857c64b513a11f69455a329681472099dce123090d320cc486a37651d6aa305",
-        "affectsGlobalScope": false
+        "signature": "0857c64b513a11f69455a329681472099dce123090d320cc486a37651d6aa305"
       },
       "./node_modules/@jupyterlab/apputils/lib/sanitizer.d.ts": {
         "version": "c377cf6d20cf1559b9f84a3d6390bdff74f001cf30df38c717a59f94debe90cb",
-        "signature": "c377cf6d20cf1559b9f84a3d6390bdff74f001cf30df38c717a59f94debe90cb",
-        "affectsGlobalScope": false
+        "signature": "c377cf6d20cf1559b9f84a3d6390bdff74f001cf30df38c717a59f94debe90cb"
       },
       "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts": {
         "version": "021d76abf950787b60632e2cddc8feecb0a5396293c83fdf53ba653f41cc62d5",
-        "signature": "021d76abf950787b60632e2cddc8feecb0a5396293c83fdf53ba653f41cc62d5",
-        "affectsGlobalScope": false
+        "signature": "021d76abf950787b60632e2cddc8feecb0a5396293c83fdf53ba653f41cc62d5"
       },
       "./node_modules/@jupyterlab/apputils/lib/splash.d.ts": {
         "version": "eac4f5574a38339604b7341b8201ff51e41442bdbe5bd5604dc99e9bd10bd484",
-        "signature": "eac4f5574a38339604b7341b8201ff51e41442bdbe5bd5604dc99e9bd10bd484",
-        "affectsGlobalScope": false
+        "signature": "eac4f5574a38339604b7341b8201ff51e41442bdbe5bd5604dc99e9bd10bd484"
       },
       "./node_modules/@jupyterlab/apputils/lib/styling.d.ts": {
         "version": "0317f14d352c00b5d5bc15ce474cbd66c439f9c84a9a7efe3be503afe53de288",
-        "signature": "0317f14d352c00b5d5bc15ce474cbd66c439f9c84a9a7efe3be503afe53de288",
-        "affectsGlobalScope": false
+        "signature": "0317f14d352c00b5d5bc15ce474cbd66c439f9c84a9a7efe3be503afe53de288"
       },
       "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts": {
         "version": "441d2aec529d378b091ad878a0169e70f6fabd522acf542ea308db7800c83e67",
-        "signature": "441d2aec529d378b091ad878a0169e70f6fabd522acf542ea308db7800c83e67",
-        "affectsGlobalScope": false
+        "signature": "441d2aec529d378b091ad878a0169e70f6fabd522acf542ea308db7800c83e67"
       },
       "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts": {
         "version": "60ec3b18b0e1ad1b237734b5299edeff5f75225349ef206d36910ad905d39cf3",
-        "signature": "60ec3b18b0e1ad1b237734b5299edeff5f75225349ef206d36910ad905d39cf3",
-        "affectsGlobalScope": false
+        "signature": "60ec3b18b0e1ad1b237734b5299edeff5f75225349ef206d36910ad905d39cf3"
       },
       "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts": {
         "version": "d7082b1c91b9c8bf2d19cbd736ef7ee8a6a7c7cff5d6989b652bd28ebd73d8b0",
-        "signature": "d7082b1c91b9c8bf2d19cbd736ef7ee8a6a7c7cff5d6989b652bd28ebd73d8b0",
-        "affectsGlobalScope": false
+        "signature": "d7082b1c91b9c8bf2d19cbd736ef7ee8a6a7c7cff5d6989b652bd28ebd73d8b0"
       },
       "./node_modules/@jupyterlab/apputils/lib/index.d.ts": {
         "version": "e6ae8d8eee6665ef714f326cc204358eb0deedf483a06f4ae65182d2c65341d8",
-        "signature": "e6ae8d8eee6665ef714f326cc204358eb0deedf483a06f4ae65182d2c65341d8",
-        "affectsGlobalScope": false
+        "signature": "e6ae8d8eee6665ef714f326cc204358eb0deedf483a06f4ae65182d2c65341d8"
       },
       "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts": {
         "version": "85497ff49b25c088caa764f9897a4b0a09825204dff99de9e75a0d6987330374",
-        "signature": "85497ff49b25c088caa764f9897a4b0a09825204dff99de9e75a0d6987330374",
-        "affectsGlobalScope": false
+        "signature": "85497ff49b25c088caa764f9897a4b0a09825204dff99de9e75a0d6987330374"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts": {
         "version": "742b86eca44220d1af6858bf5e53a8daff4c782d616ff26ca440c80f009b4552",
-        "signature": "742b86eca44220d1af6858bf5e53a8daff4c782d616ff26ca440c80f009b4552",
-        "affectsGlobalScope": false
+        "signature": "742b86eca44220d1af6858bf5e53a8daff4c782d616ff26ca440c80f009b4552"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts": {
         "version": "3b99f1016921f4d3c46ab3d08bba45e49a15e7ca5f686f7bcf850c2550b2641f",
-        "signature": "3b99f1016921f4d3c46ab3d08bba45e49a15e7ca5f686f7bcf850c2550b2641f",
-        "affectsGlobalScope": false
+        "signature": "3b99f1016921f4d3c46ab3d08bba45e49a15e7ca5f686f7bcf850c2550b2641f"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts": {
         "version": "cc2ff26093c2ac1952efcbe8f9e85274fc66957d938c7803b45d59fcb3103038",
-        "signature": "cc2ff26093c2ac1952efcbe8f9e85274fc66957d938c7803b45d59fcb3103038",
-        "affectsGlobalScope": false
+        "signature": "cc2ff26093c2ac1952efcbe8f9e85274fc66957d938c7803b45d59fcb3103038"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts": {
         "version": "34c4973d41d0a884168413ec6f954a1549f801ad83bcaefce7a242a701186b6f",
-        "signature": "34c4973d41d0a884168413ec6f954a1549f801ad83bcaefce7a242a701186b6f",
-        "affectsGlobalScope": false
+        "signature": "34c4973d41d0a884168413ec6f954a1549f801ad83bcaefce7a242a701186b6f"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts": {
         "version": "e27ebb5375f7fa7dabd19193693195cb52a59b89b3b5ce869b63b0d3e4f7ea8a",
-        "signature": "e27ebb5375f7fa7dabd19193693195cb52a59b89b3b5ce869b63b0d3e4f7ea8a",
-        "affectsGlobalScope": false
+        "signature": "e27ebb5375f7fa7dabd19193693195cb52a59b89b3b5ce869b63b0d3e4f7ea8a"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts": {
         "version": "54ad9ca565972415115f53e9d767daef39ce371b7cf06996bf062109cdd612bd",
-        "signature": "54ad9ca565972415115f53e9d767daef39ce371b7cf06996bf062109cdd612bd",
-        "affectsGlobalScope": false
+        "signature": "54ad9ca565972415115f53e9d767daef39ce371b7cf06996bf062109cdd612bd"
       },
       "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts": {
         "version": "f2535a01907d8162ab7a6f7f6135c540a7effcbc48ab6f12859cccdbfe26748b",
-        "signature": "f2535a01907d8162ab7a6f7f6135c540a7effcbc48ab6f12859cccdbfe26748b",
-        "affectsGlobalScope": false
+        "signature": "f2535a01907d8162ab7a6f7f6135c540a7effcbc48ab6f12859cccdbfe26748b"
       },
       "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts": {
         "version": "7c451c6ed0c373142a0d8f90ccb5af7cde4bc2389da79c2937c071e5f69ba714",
-        "signature": "7c451c6ed0c373142a0d8f90ccb5af7cde4bc2389da79c2937c071e5f69ba714",
-        "affectsGlobalScope": false
+        "signature": "7c451c6ed0c373142a0d8f90ccb5af7cde4bc2389da79c2937c071e5f69ba714"
       },
       "./node_modules/@jupyterlab/docregistry/lib/context.d.ts": {
         "version": "59b758ac56f4df2ca21aef9723184ca38bd2ff27c888133ba63dfc8991a37eb0",
-        "signature": "59b758ac56f4df2ca21aef9723184ca38bd2ff27c888133ba63dfc8991a37eb0",
-        "affectsGlobalScope": false
+        "signature": "59b758ac56f4df2ca21aef9723184ca38bd2ff27c888133ba63dfc8991a37eb0"
       },
       "./node_modules/@jupyterlab/docregistry/lib/default.d.ts": {
         "version": "f5743db1252aad82cc8b49b2a5c33b41a98272db59c85b9b38b16b4edc85dcb0",
-        "signature": "f5743db1252aad82cc8b49b2a5c33b41a98272db59c85b9b38b16b4edc85dcb0",
-        "affectsGlobalScope": false
+        "signature": "f5743db1252aad82cc8b49b2a5c33b41a98272db59c85b9b38b16b4edc85dcb0"
       },
       "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts": {
         "version": "18602ac631f800d530de4bc500d49b6302cbd907f4e272866292ec82dcfb9181",
-        "signature": "18602ac631f800d530de4bc500d49b6302cbd907f4e272866292ec82dcfb9181",
-        "affectsGlobalScope": false
+        "signature": "18602ac631f800d530de4bc500d49b6302cbd907f4e272866292ec82dcfb9181"
       },
       "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts": {
         "version": "91bfdd762f73f52a6eed64e988d3315b221a8a234ff2b6c5145393ede500101b",
-        "signature": "91bfdd762f73f52a6eed64e988d3315b221a8a234ff2b6c5145393ede500101b",
-        "affectsGlobalScope": false
+        "signature": "91bfdd762f73f52a6eed64e988d3315b221a8a234ff2b6c5145393ede500101b"
       },
       "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts": {
         "version": "010877b689dac0faf7d7891c4550771ccc62c7a110901b1966b59e82ffa08a27",
-        "signature": "010877b689dac0faf7d7891c4550771ccc62c7a110901b1966b59e82ffa08a27",
-        "affectsGlobalScope": false
+        "signature": "010877b689dac0faf7d7891c4550771ccc62c7a110901b1966b59e82ffa08a27"
       },
       "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts": {
         "version": "7d019f20c80f1f576cccb453ae76c73675be424e9807dc7a157ce5ad2bfc94ee",
-        "signature": "7d019f20c80f1f576cccb453ae76c73675be424e9807dc7a157ce5ad2bfc94ee",
-        "affectsGlobalScope": false
+        "signature": "7d019f20c80f1f576cccb453ae76c73675be424e9807dc7a157ce5ad2bfc94ee"
       },
       "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts": {
         "version": "79965ddf46bd41fbc40a9fae7faab25bbfd8a2d854ab40bd906b4ccc6995f39a",
-        "signature": "79965ddf46bd41fbc40a9fae7faab25bbfd8a2d854ab40bd906b4ccc6995f39a",
-        "affectsGlobalScope": false
+        "signature": "79965ddf46bd41fbc40a9fae7faab25bbfd8a2d854ab40bd906b4ccc6995f39a"
       },
       "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts": {
         "version": "1c914cecd61d906c24042040c0add3100f0c9e037651c435a0c82f8335d975a1",
-        "signature": "1c914cecd61d906c24042040c0add3100f0c9e037651c435a0c82f8335d975a1",
-        "affectsGlobalScope": false
+        "signature": "1c914cecd61d906c24042040c0add3100f0c9e037651c435a0c82f8335d975a1"
       },
       "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts": {
         "version": "d159a0c3ae2ac30283fdc3df085813cc8c3572050f4abfffef1e935db16ce5d2",
-        "signature": "d159a0c3ae2ac30283fdc3df085813cc8c3572050f4abfffef1e935db16ce5d2",
-        "affectsGlobalScope": false
+        "signature": "d159a0c3ae2ac30283fdc3df085813cc8c3572050f4abfffef1e935db16ce5d2"
       },
       "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts": {
         "version": "bee5c3609236d615fca2c68c1a3b70b723212fb3a8bc9dac6470e66449ac658f",
-        "signature": "bee5c3609236d615fca2c68c1a3b70b723212fb3a8bc9dac6470e66449ac658f",
-        "affectsGlobalScope": false
+        "signature": "bee5c3609236d615fca2c68c1a3b70b723212fb3a8bc9dac6470e66449ac658f"
       },
       "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts": {
         "version": "43373a32ae8a9daa75475fec1b571b21ab1b22fc93201be3fb1e5a97bcaed660",
-        "signature": "43373a32ae8a9daa75475fec1b571b21ab1b22fc93201be3fb1e5a97bcaed660",
-        "affectsGlobalScope": false
+        "signature": "43373a32ae8a9daa75475fec1b571b21ab1b22fc93201be3fb1e5a97bcaed660"
       },
       "./node_modules/@jupyterlab/rendermime/lib/index.d.ts": {
         "version": "6d8385fefbcc36ff0a71c3d7a8d8e3190f510ac4dc594da15833d39d3950cbc2",
-        "signature": "6d8385fefbcc36ff0a71c3d7a8d8e3190f510ac4dc594da15833d39d3950cbc2",
-        "affectsGlobalScope": false
+        "signature": "6d8385fefbcc36ff0a71c3d7a8d8e3190f510ac4dc594da15833d39d3950cbc2"
       },
       "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts": {
         "version": "db626ad600d55b012b24d93f5213142167dfaae0e48b56e1a69c64086e88e724",
-        "signature": "db626ad600d55b012b24d93f5213142167dfaae0e48b56e1a69c64086e88e724",
-        "affectsGlobalScope": false
+        "signature": "db626ad600d55b012b24d93f5213142167dfaae0e48b56e1a69c64086e88e724"
       },
       "./node_modules/@jupyterlab/docregistry/lib/index.d.ts": {
         "version": "69c33ec20590a94e1ac82e2bcfc9a038cc5aba396b6886b5429b81d9ab50728d",
-        "signature": "69c33ec20590a94e1ac82e2bcfc9a038cc5aba396b6886b5429b81d9ab50728d",
-        "affectsGlobalScope": false
+        "signature": "69c33ec20590a94e1ac82e2bcfc9a038cc5aba396b6886b5429b81d9ab50728d"
       },
       "./node_modules/@lumino/application/types/index.d.ts": {
         "version": "5f2c0f5bcc2db43de123def0b1fe6ca19d861b451aa667636c6668070aa5636d",
-        "signature": "5f2c0f5bcc2db43de123def0b1fe6ca19d861b451aa667636c6668070aa5636d",
-        "affectsGlobalScope": false
+        "signature": "5f2c0f5bcc2db43de123def0b1fe6ca19d861b451aa667636c6668070aa5636d"
       },
       "./node_modules/@jupyterlab/application/lib/frontend.d.ts": {
         "version": "93b71aeb501e4a04eb1396e924d583b9bc7a7c1c1d421de32ab0ef09cb75af99",
-        "signature": "93b71aeb501e4a04eb1396e924d583b9bc7a7c1c1d421de32ab0ef09cb75af99",
-        "affectsGlobalScope": false
+        "signature": "93b71aeb501e4a04eb1396e924d583b9bc7a7c1c1d421de32ab0ef09cb75af99"
       },
       "./node_modules/@jupyterlab/application/lib/shell.d.ts": {
         "version": "1d4aa6f44e04d59468c99828b0bec34ee3eb50a12668c62af72fafbac5196e09",
-        "signature": "1d4aa6f44e04d59468c99828b0bec34ee3eb50a12668c62af72fafbac5196e09",
-        "affectsGlobalScope": false
+        "signature": "1d4aa6f44e04d59468c99828b0bec34ee3eb50a12668c62af72fafbac5196e09"
       },
       "./node_modules/@jupyterlab/application/lib/status.d.ts": {
         "version": "784318caed930fd7ac6ae5773fa73b13af8455d03a485758e9ddedb9ae731b28",
-        "signature": "784318caed930fd7ac6ae5773fa73b13af8455d03a485758e9ddedb9ae731b28",
-        "affectsGlobalScope": false
+        "signature": "784318caed930fd7ac6ae5773fa73b13af8455d03a485758e9ddedb9ae731b28"
       },
       "./node_modules/@jupyterlab/application/lib/lab.d.ts": {
         "version": "5ffdd9d4a4c4e77bf466b0ab8f4a41cc5230d5871efca1eb4fe0f26facd5ea41",
-        "signature": "5ffdd9d4a4c4e77bf466b0ab8f4a41cc5230d5871efca1eb4fe0f26facd5ea41",
-        "affectsGlobalScope": false
+        "signature": "5ffdd9d4a4c4e77bf466b0ab8f4a41cc5230d5871efca1eb4fe0f26facd5ea41"
       },
       "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts": {
         "version": "c4e86c5fc862bc5959970d1726e38e65dbcfa99c8bdfdbffbfd92932caabd652",
-        "signature": "c4e86c5fc862bc5959970d1726e38e65dbcfa99c8bdfdbffbfd92932caabd652",
-        "affectsGlobalScope": false
+        "signature": "c4e86c5fc862bc5959970d1726e38e65dbcfa99c8bdfdbffbfd92932caabd652"
       },
       "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts": {
         "version": "7604e78316bd670a0bced63db9e8d4429db1e290ba1e334ba43655a78e5527dd",
-        "signature": "7604e78316bd670a0bced63db9e8d4429db1e290ba1e334ba43655a78e5527dd",
-        "affectsGlobalScope": false
+        "signature": "7604e78316bd670a0bced63db9e8d4429db1e290ba1e334ba43655a78e5527dd"
       },
       "./node_modules/@jupyterlab/application/lib/router.d.ts": {
         "version": "9516b24464fc256e9099edc0104165a845ca0762e622bd643486313c46767f31",
-        "signature": "9516b24464fc256e9099edc0104165a845ca0762e622bd643486313c46767f31",
-        "affectsGlobalScope": false
+        "signature": "9516b24464fc256e9099edc0104165a845ca0762e622bd643486313c46767f31"
       },
       "./node_modules/@jupyterlab/application/lib/index.d.ts": {
         "version": "7a7e8dec050f4ad9d6b093812a3a203acb13a32364079db20f7a6fde38f8427c",
-        "signature": "7a7e8dec050f4ad9d6b093812a3a203acb13a32364079db20f7a6fde38f8427c",
-        "affectsGlobalScope": false
+        "signature": "7a7e8dec050f4ad9d6b093812a3a203acb13a32364079db20f7a6fde38f8427c"
       },
       "./node_modules/@jupyterlab/launcher/lib/index.d.ts": {
         "version": "d9ac2d11a7feabbc00ab593796bbc3f84884803068a125b45666368b6f67dca3",
-        "signature": "d9ac2d11a7feabbc00ab593796bbc3f84884803068a125b45666368b6f67dca3",
-        "affectsGlobalScope": false
+        "signature": "d9ac2d11a7feabbc00ab593796bbc3f84884803068a125b45666368b6f67dca3"
+      },
+      "./src/constants.ts": {
+        "version": "9a209e179860049eb4726eddf1598f4f0d4ed21634957b2a318ded4848391d05",
+        "signature": "87418576438b2534c414c5fbd227e48f18af4c88494cd2e566a58a1bf2f1b216"
+      },
+      "./node_modules/@phosphor/widgets/lib/boxengine.d.ts": {
+        "version": "518f0974b55341500d4234068f32fa9750c3d373f41edebbb99c47798b2d102b",
+        "signature": "518f0974b55341500d4234068f32fa9750c3d373f41edebbb99c47798b2d102b"
+      },
+      "./node_modules/@phosphor/messaging/lib/index.d.ts": {
+        "version": "6d4bce054cce22306edccc85e738a800ea0364a82e85f9bf61156ed03604d24f",
+        "signature": "6d4bce054cce22306edccc85e738a800ea0364a82e85f9bf61156ed03604d24f"
+      },
+      "./node_modules/@phosphor/algorithm/lib/array.d.ts": {
+        "version": "5275faae938513e793a5ea551efa77b43a47bbfac8ed8550753ec217376f24ca",
+        "signature": "5275faae938513e793a5ea551efa77b43a47bbfac8ed8550753ec217376f24ca"
+      },
+      "./node_modules/@phosphor/algorithm/lib/iter.d.ts": {
+        "version": "b0fe7c947694eb4f0f736af28a853b0a8dc59074329a3d9a3eb5967fbe83c10d",
+        "signature": "b0fe7c947694eb4f0f736af28a853b0a8dc59074329a3d9a3eb5967fbe83c10d"
+      },
+      "./node_modules/@phosphor/algorithm/lib/chain.d.ts": {
+        "version": "5d3db7107b3138edf0ddb9851bbba99caeb6b3e32074da4c7b45e751c296183b",
+        "signature": "5d3db7107b3138edf0ddb9851bbba99caeb6b3e32074da4c7b45e751c296183b"
+      },
+      "./node_modules/@phosphor/algorithm/lib/empty.d.ts": {
+        "version": "b86137c60e0c62f7acfd8f0e761170bc6920c105ef03868c0518be562a5c5908",
+        "signature": "b86137c60e0c62f7acfd8f0e761170bc6920c105ef03868c0518be562a5c5908"
+      },
+      "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts": {
+        "version": "7ba39fedc2104c6d69f7f583e10ced54256f8d8e42770c754097e75f041cfb7d",
+        "signature": "7ba39fedc2104c6d69f7f583e10ced54256f8d8e42770c754097e75f041cfb7d"
+      },
+      "./node_modules/@phosphor/algorithm/lib/filter.d.ts": {
+        "version": "69d5afc46850b54ef3388769cd339f8dc88e15cd74a189bf71dac3937b4e8850",
+        "signature": "69d5afc46850b54ef3388769cd339f8dc88e15cd74a189bf71dac3937b4e8850"
+      },
+      "./node_modules/@phosphor/algorithm/lib/find.d.ts": {
+        "version": "a8db70d3ad601f4cf3c779623a3ca232606db0c1d052cf3f1d7a3a695bcbd368",
+        "signature": "a8db70d3ad601f4cf3c779623a3ca232606db0c1d052cf3f1d7a3a695bcbd368"
+      },
+      "./node_modules/@phosphor/algorithm/lib/map.d.ts": {
+        "version": "6256ad6e7c41a9f9ecb6349b5d5be72ea2c60ba1c6c6b3954929eb59a6980688",
+        "signature": "6256ad6e7c41a9f9ecb6349b5d5be72ea2c60ba1c6c6b3954929eb59a6980688"
+      },
+      "./node_modules/@phosphor/algorithm/lib/range.d.ts": {
+        "version": "77596a948c8deffc8f059fa0f3c38688f3b05caefa303506074034b5cb1a56ae",
+        "signature": "77596a948c8deffc8f059fa0f3c38688f3b05caefa303506074034b5cb1a56ae"
+      },
+      "./node_modules/@phosphor/algorithm/lib/reduce.d.ts": {
+        "version": "81ef0fab583499ba45dab44490620e7b870597d90c5e562ec5a9b38b6bd3fcdf",
+        "signature": "81ef0fab583499ba45dab44490620e7b870597d90c5e562ec5a9b38b6bd3fcdf"
+      },
+      "./node_modules/@phosphor/algorithm/lib/repeat.d.ts": {
+        "version": "f2b309d4f1bdf8e9f4fa03bf2183eb1b2f7cb66efb5b16da52e378ce75ac17bb",
+        "signature": "f2b309d4f1bdf8e9f4fa03bf2183eb1b2f7cb66efb5b16da52e378ce75ac17bb"
+      },
+      "./node_modules/@phosphor/algorithm/lib/retro.d.ts": {
+        "version": "9cbaf0317ec49acb6c84d142077670a301015979260c4ecded7705fd2141379c",
+        "signature": "9cbaf0317ec49acb6c84d142077670a301015979260c4ecded7705fd2141379c"
+      },
+      "./node_modules/@phosphor/algorithm/lib/sort.d.ts": {
+        "version": "5a49d16b6f7d3ca5c66569784290c0ed7a3d74821095e2ab91e17ea444ac4657",
+        "signature": "5a49d16b6f7d3ca5c66569784290c0ed7a3d74821095e2ab91e17ea444ac4657"
+      },
+      "./node_modules/@phosphor/algorithm/lib/stride.d.ts": {
+        "version": "2e5fab5fe6e398cb14f695da07044a65f4e32c8d0fe9b31f5fe52d2cc7656230",
+        "signature": "2e5fab5fe6e398cb14f695da07044a65f4e32c8d0fe9b31f5fe52d2cc7656230"
+      },
+      "./node_modules/@phosphor/algorithm/lib/string.d.ts": {
+        "version": "92e581f3d154511056bfba03e72ed3cffa92681b4b9bb1953b0b724f67a664bc",
+        "signature": "92e581f3d154511056bfba03e72ed3cffa92681b4b9bb1953b0b724f67a664bc"
+      },
+      "./node_modules/@phosphor/algorithm/lib/take.d.ts": {
+        "version": "c9deb61903fd8318e6845e4e0f03b3bd813cdae1778f8dc9ee0ec05f9ca22094",
+        "signature": "c9deb61903fd8318e6845e4e0f03b3bd813cdae1778f8dc9ee0ec05f9ca22094"
+      },
+      "./node_modules/@phosphor/algorithm/lib/zip.d.ts": {
+        "version": "7bc3152a4c8adf395ad486da44acb6e8c98dedd2becc83810b076114338a5045",
+        "signature": "7bc3152a4c8adf395ad486da44acb6e8c98dedd2becc83810b076114338a5045"
+      },
+      "./node_modules/@phosphor/algorithm/lib/index.d.ts": {
+        "version": "30a8688575aeada46c1268d671b2a1de78705ebc0d5343e75b96c25f149caa98",
+        "signature": "30a8688575aeada46c1268d671b2a1de78705ebc0d5343e75b96c25f149caa98"
+      },
+      "./node_modules/@phosphor/signaling/lib/index.d.ts": {
+        "version": "e29b5eb559a057d36584ec480d49711f0c81bed176bb6256df584e800c453760",
+        "signature": "e29b5eb559a057d36584ec480d49711f0c81bed176bb6256df584e800c453760"
+      },
+      "./node_modules/@phosphor/disposable/lib/index.d.ts": {
+        "version": "57e52fd41767e09990c28cd092037736625b3c492c412d7b5c72282a4a97e2be",
+        "signature": "57e52fd41767e09990c28cd092037736625b3c492c412d7b5c72282a4a97e2be"
+      },
+      "./node_modules/@phosphor/widgets/lib/title.d.ts": {
+        "version": "02906328718f740db2bd453ed956e9b954b5ca10511695a44f6e8c25c3db8a40",
+        "signature": "02906328718f740db2bd453ed956e9b954b5ca10511695a44f6e8c25c3db8a40"
+      },
+      "./node_modules/@phosphor/widgets/lib/widget.d.ts": {
+        "version": "b532781d9096fd879f4292fbbe656fac7cf51a3d3628a562d40fe0b29cb3d8ff",
+        "signature": "b532781d9096fd879f4292fbbe656fac7cf51a3d3628a562d40fe0b29cb3d8ff"
+      },
+      "./node_modules/@phosphor/widgets/lib/layout.d.ts": {
+        "version": "5350283d2aee045bf447f38aa46474cc2dc46c5e304ff05fd71a4539c6de67f9",
+        "signature": "5350283d2aee045bf447f38aa46474cc2dc46c5e304ff05fd71a4539c6de67f9"
+      },
+      "./node_modules/@phosphor/widgets/lib/panellayout.d.ts": {
+        "version": "f9e8dc69b67c409b6dd500317065381e70eeb45774a2b6a2d267797277789856",
+        "signature": "f9e8dc69b67c409b6dd500317065381e70eeb45774a2b6a2d267797277789856"
+      },
+      "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts": {
+        "version": "61bfa4334dbf9c4bd1d9fcd66243f15e9bd1aa9d6c57d329c1f976e706b3b07a",
+        "signature": "61bfa4334dbf9c4bd1d9fcd66243f15e9bd1aa9d6c57d329c1f976e706b3b07a"
+      },
+      "./node_modules/@phosphor/widgets/lib/panel.d.ts": {
+        "version": "d9bda13de04067b09bd723693fd3c87583b958d3593f0881e333fb75fa9e79e3",
+        "signature": "d9bda13de04067b09bd723693fd3c87583b958d3593f0881e333fb75fa9e79e3"
+      },
+      "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts": {
+        "version": "6742b16104faa968b6daf0d577348e7be96c5988492c8bf5616fa79209de3906",
+        "signature": "6742b16104faa968b6daf0d577348e7be96c5988492c8bf5616fa79209de3906"
+      },
+      "./node_modules/@phosphor/coreutils/lib/json.d.ts": {
+        "version": "9d441989d1cbb52939625e57621620524bf19c3c223f01007941ecd10335d0d1",
+        "signature": "9d441989d1cbb52939625e57621620524bf19c3c223f01007941ecd10335d0d1"
+      },
+      "./node_modules/@phosphor/coreutils/lib/mime.d.ts": {
+        "version": "28e06b63c3f364ef754eedfb0cb0f5127011f3d685e102f07ff5c56aa87d1562",
+        "signature": "28e06b63c3f364ef754eedfb0cb0f5127011f3d685e102f07ff5c56aa87d1562"
+      },
+      "./node_modules/@phosphor/coreutils/lib/promise.d.ts": {
+        "version": "b0ee12813f8d26468aba1fd860db8180eb9e332183ad839dd554a2f19c8983cc",
+        "signature": "b0ee12813f8d26468aba1fd860db8180eb9e332183ad839dd554a2f19c8983cc"
+      },
+      "./node_modules/@phosphor/coreutils/lib/random.d.ts": {
+        "version": "b407b6761debdcd11022f0157535e7bc4977433fc09b6c188cd7c324ded64a5d",
+        "signature": "b407b6761debdcd11022f0157535e7bc4977433fc09b6c188cd7c324ded64a5d"
+      },
+      "./node_modules/@phosphor/coreutils/lib/token.d.ts": {
+        "version": "4873fe69c2bd7be609e6f3f033db4534b88735ff0769e18cb100cbf24f25e0f1",
+        "signature": "4873fe69c2bd7be609e6f3f033db4534b88735ff0769e18cb100cbf24f25e0f1"
+      },
+      "./node_modules/@phosphor/coreutils/lib/uuid.d.ts": {
+        "version": "094815f0e8d3c53c1b983debb0559cb347ad78142419654b6093ce285aa150cd",
+        "signature": "094815f0e8d3c53c1b983debb0559cb347ad78142419654b6093ce285aa150cd"
+      },
+      "./node_modules/@phosphor/coreutils/lib/index.d.ts": {
+        "version": "cc0fca544c9ee63d754899e93ebae35c8ba8304a100126b9c3dadee2c91a2250",
+        "signature": "cc0fca544c9ee63d754899e93ebae35c8ba8304a100126b9c3dadee2c91a2250"
+      },
+      "./node_modules/@phosphor/commands/lib/index.d.ts": {
+        "version": "f7a4e242113dbee5fdbc1340ae8fa59fa1d92eeb41d3a9f2a7f34434036d8e87",
+        "signature": "f7a4e242113dbee5fdbc1340ae8fa59fa1d92eeb41d3a9f2a7f34434036d8e87"
+      },
+      "./node_modules/@phosphor/virtualdom/lib/index.d.ts": {
+        "version": "e582863f95c72400f8ddadeee51f6339c484aad6815b62a646b6bbedf4f579e2",
+        "signature": "e582863f95c72400f8ddadeee51f6339c484aad6815b62a646b6bbedf4f579e2"
+      },
+      "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts": {
+        "version": "1db72b5c0ab78997e0ce774d3ec782288690a3527c9afa2395fd8f0aea1d1dae",
+        "signature": "1db72b5c0ab78997e0ce774d3ec782288690a3527c9afa2395fd8f0aea1d1dae"
+      },
+      "./node_modules/@phosphor/widgets/lib/menu.d.ts": {
+        "version": "5d2d8228652d10324f96849e4ae8cc8eeadcf6ca72ef6e0398f6998e94d19915",
+        "signature": "5d2d8228652d10324f96849e4ae8cc8eeadcf6ca72ef6e0398f6998e94d19915"
+      },
+      "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts": {
+        "version": "a58928566bd438cace363dd567a9a8df609a82166d487dff5e6820b0215fd01e",
+        "signature": "a58928566bd438cace363dd567a9a8df609a82166d487dff5e6820b0215fd01e"
+      },
+      "./node_modules/@phosphor/widgets/lib/tabbar.d.ts": {
+        "version": "4e34c1aefcb13a420bc0255e2ee6452110d3d4c2a58821f681d81fc51c280f50",
+        "signature": "4e34c1aefcb13a420bc0255e2ee6452110d3d4c2a58821f681d81fc51c280f50"
+      },
+      "./node_modules/@phosphor/widgets/lib/docklayout.d.ts": {
+        "version": "647ef68c9129fd074bfe02783c4202c1768cd9c490632b574a246f0a5ec7ccd9",
+        "signature": "647ef68c9129fd074bfe02783c4202c1768cd9c490632b574a246f0a5ec7ccd9"
+      },
+      "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts": {
+        "version": "6fb0cad19f294c0e0f12adf0d3404649a6779186d9499f9a7b4b234531736491",
+        "signature": "6fb0cad19f294c0e0f12adf0d3404649a6779186d9499f9a7b4b234531736491"
+      },
+      "./node_modules/@phosphor/widgets/lib/focustracker.d.ts": {
+        "version": "269a9559f1d701c5c31cac903e6d6cecd2116321b0113a62bfe21433e85ed236",
+        "signature": "269a9559f1d701c5c31cac903e6d6cecd2116321b0113a62bfe21433e85ed236"
+      },
+      "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts": {
+        "version": "cc71c2b4ac696b027eff499027d4d5febb9a6ead9cc3f81a310bb7d8e39752ff",
+        "signature": "cc71c2b4ac696b027eff499027d4d5febb9a6ead9cc3f81a310bb7d8e39752ff"
+      },
+      "./node_modules/@phosphor/widgets/lib/menubar.d.ts": {
+        "version": "e64e93eca04ceacfaf726ba306e41b04f7a29943aa57c36486f016e27321894c",
+        "signature": "e64e93eca04ceacfaf726ba306e41b04f7a29943aa57c36486f016e27321894c"
+      },
+      "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts": {
+        "version": "2f3b5535020128e321e7e24c186ae8079267c213965315b08e29af9c93bf44df",
+        "signature": "2f3b5535020128e321e7e24c186ae8079267c213965315b08e29af9c93bf44df"
+      },
+      "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts": {
+        "version": "a47f0b0ea63dc40176bfea2bd26f40e59dda410acce93594c4bd0fb25d314c08",
+        "signature": "a47f0b0ea63dc40176bfea2bd26f40e59dda410acce93594c4bd0fb25d314c08"
+      },
+      "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts": {
+        "version": "07f9bd74c94fc6337534679f78e91e113bfbbec0e6994e4ea4d12002800a9221",
+        "signature": "07f9bd74c94fc6337534679f78e91e113bfbbec0e6994e4ea4d12002800a9221"
+      },
+      "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts": {
+        "version": "f49aecef81c20d28b6c02d0b541aa6fd27c92cb577eb8b6cc809fee5cfb4c87d",
+        "signature": "f49aecef81c20d28b6c02d0b541aa6fd27c92cb577eb8b6cc809fee5cfb4c87d"
+      },
+      "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts": {
+        "version": "6e771f66549892608000cb2ced46e2f6b1bd32498357166d2b972edb996e917e",
+        "signature": "6e771f66549892608000cb2ced46e2f6b1bd32498357166d2b972edb996e917e"
+      },
+      "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts": {
+        "version": "e669ba06b92a6457dbd3d8fa2a2cc8652f17f177a985ad8d7d4a716be960496f",
+        "signature": "e669ba06b92a6457dbd3d8fa2a2cc8652f17f177a985ad8d7d4a716be960496f"
+      },
+      "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts": {
+        "version": "e0b9646e6407be4123c23fd79c53f899f8484cfe6af5f7dd1ed6f12eda7e0dbe",
+        "signature": "e0b9646e6407be4123c23fd79c53f899f8484cfe6af5f7dd1ed6f12eda7e0dbe"
+      },
+      "./node_modules/@phosphor/widgets/lib/index.d.ts": {
+        "version": "ce75ab9766be65e1b6837cba39ea25ebfbe25f431e0f97e1863743817fad2d91",
+        "signature": "ce75ab9766be65e1b6837cba39ea25ebfbe25f431e0f97e1863743817fad2d91"
+      },
+      "./src/leftsidelauncher.ts": {
+        "version": "4aad8e64dd7e47561f78e1271ef72768c6b069186979cbada3f4d462a7bb7f4f",
+        "signature": "db2f5f64826f0304cf778d51b135c1bc8eb69289a5a8217106055ef1a752dbf1"
+      },
+      "./src/mainlauncher.ts": {
+        "version": "b2ed6cd82f44377c8ea2f6b97a5ff2af22828e9b350c3908850000d590c9d296",
+        "signature": "bc20ff78e9b1df162745ac36b63b928733e19b035a61cd4a509d8159dbc1d1e8"
       },
       "./src/aws_glue_databrew_extension.ts": {
-        "version": "b5439c471c829020b181d07f5dc577b1041cfcfcfd01773901cec7f5308c4d18",
-        "signature": "08b5bccdfbe9797c8f97abbdcb1b3fe2ec54345cbadf9b27c4c829c91a066653",
-        "affectsGlobalScope": false
+        "version": "cc3d045ce8a80d824f2b4080eac650d3f2f3dc80ff0241e31c574f93c423cf0f",
+        "signature": "eeb642b57a8891c39dca104f1ca10bbaff45d1fe7e3d0fb0632333dd32271eb6"
       },
       "./src/index.ts": {
         "version": "bafc391b4efa5a1a01be881b76eaedc0d522766a067215a8db6bafed9a039ba7",
-        "signature": "ba8cdf6e5e786fee2541e7a49f93e1afd52fcb2730ae95374fcaa2eebac6efe4",
-        "affectsGlobalScope": false
+        "signature": "ba8cdf6e5e786fee2541e7a49f93e1afd52fcb2730ae95374fcaa2eebac6efe4"
       },
       "./src/svg_icons.d.ts": {
         "version": "5563c7802bed1a2215fde8b593aee660267b6730508153641e8ce76a50a3024d",
-        "signature": "5563c7802bed1a2215fde8b593aee660267b6730508153641e8ce76a50a3024d",
-        "affectsGlobalScope": false
+        "signature": "5563c7802bed1a2215fde8b593aee660267b6730508153641e8ce76a50a3024d"
       }
     },
     "options": {
@@ -1814,1309 +1696,13 @@
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts",
-        "./node_modules/popper.js/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts": [
-        "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts": [
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/frontend.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/application/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts",
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@jupyterlab/application/lib/lab.d.ts",
-        "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts",
-        "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts",
-        "./node_modules/@jupyterlab/application/lib/router.d.ts",
-        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
-        "./node_modules/@jupyterlab/application/lib/status.d.ts",
-        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/lab.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
-        "./node_modules/@jupyterlab/application/lib/status.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/index.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/router.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/tokens.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/shell.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/status.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts": [
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/domutils.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/hoverbox.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/sanitizer.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/styling.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts": [
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/url.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/launcher/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/config/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/session/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/session.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/session.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
-        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts": [
-        "./node_modules/typestyle/lib/types.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      "./node_modules/@lumino/coreutils/types/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/json.d.ts",
+        "./node_modules/@lumino/coreutils/types/mime.d.ts",
+        "./node_modules/@lumino/coreutils/types/promise.d.ts",
+        "./node_modules/@lumino/coreutils/types/random.d.ts",
+        "./node_modules/@lumino/coreutils/types/token.d.ts",
+        "./node_modules/@lumino/coreutils/types/uuid.d.ts"
       ],
       "./node_modules/@lumino/algorithm/types/chain.d.ts": [
         "./node_modules/@lumino/algorithm/types/iter.d.ts"
@@ -3132,25 +1718,6 @@
       ],
       "./node_modules/@lumino/algorithm/types/find.d.ts": [
         "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/index.d.ts": [
-        "./node_modules/@lumino/algorithm/types/array.d.ts",
-        "./node_modules/@lumino/algorithm/types/chain.d.ts",
-        "./node_modules/@lumino/algorithm/types/empty.d.ts",
-        "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
-        "./node_modules/@lumino/algorithm/types/filter.d.ts",
-        "./node_modules/@lumino/algorithm/types/find.d.ts",
-        "./node_modules/@lumino/algorithm/types/iter.d.ts",
-        "./node_modules/@lumino/algorithm/types/map.d.ts",
-        "./node_modules/@lumino/algorithm/types/range.d.ts",
-        "./node_modules/@lumino/algorithm/types/reduce.d.ts",
-        "./node_modules/@lumino/algorithm/types/repeat.d.ts",
-        "./node_modules/@lumino/algorithm/types/retro.d.ts",
-        "./node_modules/@lumino/algorithm/types/sort.d.ts",
-        "./node_modules/@lumino/algorithm/types/stride.d.ts",
-        "./node_modules/@lumino/algorithm/types/string.d.ts",
-        "./node_modules/@lumino/algorithm/types/take.d.ts",
-        "./node_modules/@lumino/algorithm/types/zip.d.ts"
       ],
       "./node_modules/@lumino/algorithm/types/map.d.ts": [
         "./node_modules/@lumino/algorithm/types/iter.d.ts"
@@ -3179,10 +1746,28 @@
       "./node_modules/@lumino/algorithm/types/zip.d.ts": [
         "./node_modules/@lumino/algorithm/types/iter.d.ts"
       ],
-      "./node_modules/@lumino/application/types/index.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+      "./node_modules/@lumino/algorithm/types/index.d.ts": [
+        "./node_modules/@lumino/algorithm/types/array.d.ts",
+        "./node_modules/@lumino/algorithm/types/chain.d.ts",
+        "./node_modules/@lumino/algorithm/types/empty.d.ts",
+        "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
+        "./node_modules/@lumino/algorithm/types/filter.d.ts",
+        "./node_modules/@lumino/algorithm/types/find.d.ts",
+        "./node_modules/@lumino/algorithm/types/iter.d.ts",
+        "./node_modules/@lumino/algorithm/types/map.d.ts",
+        "./node_modules/@lumino/algorithm/types/range.d.ts",
+        "./node_modules/@lumino/algorithm/types/reduce.d.ts",
+        "./node_modules/@lumino/algorithm/types/repeat.d.ts",
+        "./node_modules/@lumino/algorithm/types/retro.d.ts",
+        "./node_modules/@lumino/algorithm/types/sort.d.ts",
+        "./node_modules/@lumino/algorithm/types/stride.d.ts",
+        "./node_modules/@lumino/algorithm/types/string.d.ts",
+        "./node_modules/@lumino/algorithm/types/take.d.ts",
+        "./node_modules/@lumino/algorithm/types/zip.d.ts"
+      ],
+      "./node_modules/@lumino/disposable/types/index.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
       ],
       "./node_modules/@lumino/commands/types/index.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
@@ -3190,36 +1775,339 @@
         "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/virtualdom/types/index.d.ts"
       ],
-      "./node_modules/@lumino/coreutils/types/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/json.d.ts",
-        "./node_modules/@lumino/coreutils/types/mime.d.ts",
-        "./node_modules/@lumino/coreutils/types/promise.d.ts",
-        "./node_modules/@lumino/coreutils/types/random.d.ts",
-        "./node_modules/@lumino/coreutils/types/token.d.ts",
-        "./node_modules/@lumino/coreutils/types/uuid.d.ts"
+      "./node_modules/@jupyterlab/services/lib/config/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts"
       ],
-      "./node_modules/@lumino/disposable/types/index.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@lumino/polling/types/index.d.ts": [
+      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts": [
         "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/poll.d.ts",
-        "./node_modules/@lumino/polling/types/ratelimiter.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
         "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts"
       ],
       "./node_modules/@lumino/polling/types/poll.d.ts": [
         "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts"
       ],
       "./node_modules/@lumino/polling/types/ratelimiter.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/polling/types/index.d.ts",
         "./node_modules/@lumino/polling/types/poll.d.ts"
       ],
+      "./node_modules/@lumino/polling/types/index.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/poll.d.ts",
+        "./node_modules/@lumino/polling/types/ratelimiter.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts": [
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/url.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/session.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts": [
+        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/manager.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/manager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/tokens.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts": [
+        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/title.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/widget.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
+        "./node_modules/@lumino/widgets/types/title.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/layout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/panellayout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
       "./node_modules/@lumino/widgets/types/boxlayout.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/panel.d.ts": [
         "./node_modules/@lumino/widgets/types/panellayout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
@@ -3229,9 +2117,17 @@
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/commandpalette.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/menu.d.ts": [
         "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/virtualdom/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
@@ -3239,6 +2135,13 @@
         "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/disposable/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/menu.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/tabbar.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/title.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/docklayout.d.ts": [
         "./node_modules/@lumino/algorithm/types/index.d.ts",
@@ -3266,60 +2169,11 @@
         "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/index.d.ts": [
-        "./node_modules/@lumino/widgets/types/boxengine.d.ts",
-        "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/boxpanel.d.ts",
-        "./node_modules/@lumino/widgets/types/commandpalette.d.ts",
-        "./node_modules/@lumino/widgets/types/contextmenu.d.ts",
-        "./node_modules/@lumino/widgets/types/docklayout.d.ts",
-        "./node_modules/@lumino/widgets/types/dockpanel.d.ts",
-        "./node_modules/@lumino/widgets/types/focustracker.d.ts",
-        "./node_modules/@lumino/widgets/types/gridlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
-        "./node_modules/@lumino/widgets/types/menu.d.ts",
-        "./node_modules/@lumino/widgets/types/menubar.d.ts",
-        "./node_modules/@lumino/widgets/types/panel.d.ts",
-        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
-        "./node_modules/@lumino/widgets/types/scrollbar.d.ts",
-        "./node_modules/@lumino/widgets/types/singletonlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/splitpanel.d.ts",
-        "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
-        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
-        "./node_modules/@lumino/widgets/types/tabpanel.d.ts",
-        "./node_modules/@lumino/widgets/types/title.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/layout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/menu.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
       "./node_modules/@lumino/widgets/types/menubar.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/virtualdom/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/menu.d.ts",
         "./node_modules/@lumino/widgets/types/title.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/panel.d.ts": [
-        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/panellayout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/scrollbar.d.ts": [
@@ -3354,678 +2208,1362 @@
         "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/tabbar.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/title.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
       "./node_modules/@lumino/widgets/types/tabpanel.d.ts": [
         "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
         "./node_modules/@lumino/widgets/types/tabbar.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/title.d.ts": [
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      "./node_modules/@lumino/widgets/types/index.d.ts": [
+        "./node_modules/@lumino/widgets/types/boxengine.d.ts",
+        "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/boxpanel.d.ts",
+        "./node_modules/@lumino/widgets/types/commandpalette.d.ts",
+        "./node_modules/@lumino/widgets/types/contextmenu.d.ts",
+        "./node_modules/@lumino/widgets/types/docklayout.d.ts",
+        "./node_modules/@lumino/widgets/types/dockpanel.d.ts",
+        "./node_modules/@lumino/widgets/types/focustracker.d.ts",
+        "./node_modules/@lumino/widgets/types/gridlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
+        "./node_modules/@lumino/widgets/types/menu.d.ts",
+        "./node_modules/@lumino/widgets/types/menubar.d.ts",
+        "./node_modules/@lumino/widgets/types/panel.d.ts",
+        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/scrollbar.d.ts",
+        "./node_modules/@lumino/widgets/types/singletonlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/splitpanel.d.ts",
+        "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
+        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
+        "./node_modules/@lumino/widgets/types/tabpanel.d.ts",
+        "./node_modules/@lumino/widgets/types/title.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/widget.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
-        "./node_modules/@lumino/widgets/types/title.d.ts"
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
       "./node_modules/@types/react/index.d.ts": [
+        "./node_modules/@types/react/node_modules/csstype/index.d.ts",
         "./node_modules/@types/prop-types/index.d.ts",
-        "./node_modules/@types/react/global.d.ts",
-        "./node_modules/csstype/index.d.ts"
+        "./node_modules/@types/react/global.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts": [
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts"
       ],
       "./node_modules/typestyle/lib/types.d.ts": [
         "./node_modules/csstype/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts": [
+        "./node_modules/typestyle/lib/types.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts": [
+        "./node_modules/popper.js/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts": [
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts": [
+        "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts": [
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/domutils.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/hoverbox.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/sanitizer.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/styling.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts": [
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
+      ],
+      "./node_modules/@lumino/application/types/index.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/frontend.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/application/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/shell.d.ts": [
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/status.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/lab.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
+        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
+        "./node_modules/@jupyterlab/application/lib/status.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/shell.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/router.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
+        "./node_modules/@jupyterlab/application/lib/lab.d.ts",
+        "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts",
+        "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts",
+        "./node_modules/@jupyterlab/application/lib/router.d.ts",
+        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
+        "./node_modules/@jupyterlab/application/lib/status.d.ts",
+        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/launcher/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/chain.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/empty.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/filter.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/find.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/map.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/range.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/reduce.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/repeat.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/retro.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/sort.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/stride.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/take.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/zip.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/index.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/array.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/chain.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/empty.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/filter.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/find.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/map.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/range.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/reduce.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/repeat.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/retro.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/sort.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/stride.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/string.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/take.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/zip.d.ts"
+      ],
+      "./node_modules/@phosphor/disposable/lib/index.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/title.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/widget.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/layout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/panellayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/panel.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/coreutils/lib/index.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/json.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/mime.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/promise.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/random.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/token.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/uuid.d.ts"
+      ],
+      "./node_modules/@phosphor/commands/lib/index.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/menu.d.ts": [
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts": [
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/tabbar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/docklayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/docklayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/focustracker.d.ts": [
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/menubar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/index.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/boxengine.d.ts",
+        "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts",
+        "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/docklayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/focustracker.d.ts",
+        "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menubar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./src/leftsidelauncher.ts": [
+        "./node_modules/@phosphor/widgets/lib/index.d.ts",
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./src/constants.ts"
+      ],
+      "./src/mainlauncher.ts": [
+        "./node_modules/@phosphor/widgets/lib/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
       "./src/aws_glue_databrew_extension.ts": [
         "./node_modules/@jupyterlab/application/lib/index.d.ts",
         "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
         "./node_modules/@jupyterlab/launcher/lib/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./src/svg_icons.d.ts"
+        "./src/constants.ts",
+        "./src/leftsidelauncher.ts",
+        "./src/mainlauncher.ts"
       ],
       "./src/index.ts": [
         "./src/aws_glue_databrew_extension.ts"
       ]
     },
     "exportedModulesMap": {
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
-        "./node_modules/@types/react/index.d.ts",
-        "./node_modules/popper.js/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/core/lib/esm/index.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
-        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts"
-      ],
-      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts": [
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
-        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts": [
-        "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts": [
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts": [
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/frontend.d.ts": [
+      "./node_modules/@lumino/coreutils/types/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/json.d.ts",
+        "./node_modules/@lumino/coreutils/types/mime.d.ts",
+        "./node_modules/@lumino/coreutils/types/promise.d.ts",
+        "./node_modules/@lumino/coreutils/types/random.d.ts",
+        "./node_modules/@lumino/coreutils/types/token.d.ts",
+        "./node_modules/@lumino/coreutils/types/uuid.d.ts"
+      ],
+      "./node_modules/@jupyterlab/launcher/lib/index.d.ts": [
         "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
         "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/application/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./src/aws_glue_databrew_extension.ts": [
+        "./node_modules/@jupyterlab/application/lib/index.d.ts"
+      ],
+      "./src/index.ts": [
+        "./node_modules/@jupyterlab/application/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/router.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
       ],
       "./node_modules/@jupyterlab/application/lib/index.d.ts": [
         "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts",
@@ -4038,84 +3576,201 @@
         "./node_modules/@jupyterlab/application/lib/status.d.ts",
         "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
       ],
-      "./node_modules/@jupyterlab/application/lib/lab.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
-        "./node_modules/@jupyterlab/application/lib/status.d.ts",
+      "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
         "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/index.d.ts"
       ],
       "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
         "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
         "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
         "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/shell.d.ts"
       ],
-      "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/index.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
+      "./node_modules/@jupyterlab/application/lib/lab.d.ts": [
         "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
+        "./node_modules/@jupyterlab/application/lib/shell.d.ts",
+        "./node_modules/@jupyterlab/application/lib/status.d.ts"
       ],
-      "./node_modules/@jupyterlab/application/lib/router.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/tokens.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
+      "./node_modules/@jupyterlab/application/lib/status.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts"
       ],
       "./node_modules/@jupyterlab/application/lib/shell.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
         "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
         "./node_modules/@lumino/algorithm/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/application/lib/frontend.d.ts"
       ],
-      "./node_modules/@jupyterlab/application/lib/status.d.ts": [
-        "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/application/lib/tokens.d.ts": [
+      "./node_modules/@jupyterlab/application/lib/frontend.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
         "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/application/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
-      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts": [
+      "./node_modules/@lumino/application/types/index.d.ts": [
         "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
-      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
+        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
       ],
-      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts": [
+      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts": [
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts": [
+        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
       ],
       "./node_modules/@jupyterlab/apputils/lib/index.d.ts": [
         "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts",
@@ -4141,716 +3796,70 @@
         "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
         "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts"
       ],
-      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts": [
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts": [
+      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts": [
         "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts"
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts"
       ],
       "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
-        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
         "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
         "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
         "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
         "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+        "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts"
       ],
-      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts": [
         "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
       ],
       "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
         "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
         "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts": [
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/url.d.ts"
-      ],
-      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
-        "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/launcher/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
-        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts": [
-        "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/config/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts": [
-        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts": [
-        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/session/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/session.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/services/lib/session/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/session/session.d.ts": [
-        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-        "./node_modules/@jupyterlab/services/lib/index.d.ts",
-        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts": [
-        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
-        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts": [
-        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts": [
-        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts",
-        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
-        "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@types/react/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts": [
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
-        "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts": [
-        "./node_modules/typestyle/lib/types.d.ts"
-      ],
-      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts": [
-        "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts"
+        "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/printing.d.ts"
       ],
       "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts"
       ],
-      "./node_modules/@lumino/algorithm/types/chain.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts"
       ],
-      "./node_modules/@lumino/algorithm/types/empty.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/enumerate.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/filter.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/find.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/index.d.ts": [
-        "./node_modules/@lumino/algorithm/types/array.d.ts",
-        "./node_modules/@lumino/algorithm/types/chain.d.ts",
-        "./node_modules/@lumino/algorithm/types/empty.d.ts",
-        "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
-        "./node_modules/@lumino/algorithm/types/filter.d.ts",
-        "./node_modules/@lumino/algorithm/types/find.d.ts",
-        "./node_modules/@lumino/algorithm/types/iter.d.ts",
-        "./node_modules/@lumino/algorithm/types/map.d.ts",
-        "./node_modules/@lumino/algorithm/types/range.d.ts",
-        "./node_modules/@lumino/algorithm/types/reduce.d.ts",
-        "./node_modules/@lumino/algorithm/types/repeat.d.ts",
-        "./node_modules/@lumino/algorithm/types/retro.d.ts",
-        "./node_modules/@lumino/algorithm/types/sort.d.ts",
-        "./node_modules/@lumino/algorithm/types/stride.d.ts",
-        "./node_modules/@lumino/algorithm/types/string.d.ts",
-        "./node_modules/@lumino/algorithm/types/take.d.ts",
-        "./node_modules/@lumino/algorithm/types/zip.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/map.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/range.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/reduce.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/repeat.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/retro.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/sort.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/stride.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/take.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/algorithm/types/zip.d.ts": [
-        "./node_modules/@lumino/algorithm/types/iter.d.ts"
-      ],
-      "./node_modules/@lumino/application/types/index.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
-      "./node_modules/@lumino/commands/types/index.d.ts": [
+      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts": [
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/virtualdom/types/index.d.ts"
       ],
-      "./node_modules/@lumino/coreutils/types/index.d.ts": [
-        "./node_modules/@lumino/coreutils/types/json.d.ts",
-        "./node_modules/@lumino/coreutils/types/mime.d.ts",
-        "./node_modules/@lumino/coreutils/types/promise.d.ts",
-        "./node_modules/@lumino/coreutils/types/random.d.ts",
-        "./node_modules/@lumino/coreutils/types/token.d.ts",
-        "./node_modules/@lumino/coreutils/types/uuid.d.ts"
-      ],
-      "./node_modules/@lumino/disposable/types/index.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@lumino/polling/types/index.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/poll.d.ts",
-        "./node_modules/@lumino/polling/types/ratelimiter.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@lumino/polling/types/poll.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts"
-      ],
-      "./node_modules/@lumino/polling/types/ratelimiter.d.ts": [
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/index.d.ts",
-        "./node_modules/@lumino/polling/types/poll.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/boxlayout.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/boxpanel.d.ts": [
-        "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
-        "./node_modules/@lumino/widgets/types/panel.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/commandpalette.d.ts": [
+      "./node_modules/@lumino/widgets/types/menu.d.ts": [
         "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/coreutils/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/contextmenu.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/menu.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/docklayout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
-        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/dockpanel.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/docklayout.d.ts",
-        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/focustracker.d.ts": [
-        "./node_modules/@lumino/disposable/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/gridlayout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/index.d.ts": [
@@ -4879,19 +3888,83 @@
         "./node_modules/@lumino/widgets/types/title.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/layout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
+      "./src/mainlauncher.ts": [
+        "./node_modules/@phosphor/widgets/lib/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./src/leftsidelauncher.ts": [
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts": [
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts": [
         "./node_modules/@lumino/disposable/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/menu.d.ts": [
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/coreutils/types/index.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts": [
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts": [
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts": [
+        "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
         "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
+        "./node_modules/@lumino/widgets/types/index.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/menubar.d.ts": [
         "./node_modules/@lumino/messaging/types/index.d.ts",
@@ -4900,34 +3973,360 @@
         "./node_modules/@lumino/widgets/types/title.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/panel.d.ts": [
-        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      "./node_modules/@lumino/widgets/types/contextmenu.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/menu.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/panellayout.d.ts": [
-        "./node_modules/@lumino/algorithm/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/layout.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
-      "./node_modules/@lumino/widgets/types/scrollbar.d.ts": [
+      "./node_modules/@lumino/widgets/types/commandpalette.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/commands/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/tokens.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts": [
+        "./node_modules/@jupyterlab/application/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/manager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/manager.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/session.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/config/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts": [
+        "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+        "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts": [
+        "./node_modules/@lumino/commands/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts": [
+        "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
+        "./node_modules/@jupyterlab/coreutils/lib/url.d.ts"
+      ],
+      "./node_modules/@lumino/polling/types/ratelimiter.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/poll.d.ts"
+      ],
+      "./node_modules/@lumino/polling/types/index.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/poll.d.ts",
+        "./node_modules/@lumino/polling/types/ratelimiter.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts": [
+        "./node_modules/@lumino/polling/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts"
+      ],
+      "./node_modules/@lumino/polling/types/poll.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/polling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+        "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts": [
+        "./node_modules/@jupyterlab/nbformat/lib/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/index.d.ts": [
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts"
+      ],
+      "./node_modules/@lumino/commands/types/index.d.ts": [
+        "./node_modules/@lumino/coreutils/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/index.d.ts": [
+        "./node_modules/@lumino/algorithm/types/array.d.ts",
+        "./node_modules/@lumino/algorithm/types/chain.d.ts",
+        "./node_modules/@lumino/algorithm/types/empty.d.ts",
+        "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
+        "./node_modules/@lumino/algorithm/types/filter.d.ts",
+        "./node_modules/@lumino/algorithm/types/find.d.ts",
+        "./node_modules/@lumino/algorithm/types/iter.d.ts",
+        "./node_modules/@lumino/algorithm/types/map.d.ts",
+        "./node_modules/@lumino/algorithm/types/range.d.ts",
+        "./node_modules/@lumino/algorithm/types/reduce.d.ts",
+        "./node_modules/@lumino/algorithm/types/repeat.d.ts",
+        "./node_modules/@lumino/algorithm/types/retro.d.ts",
+        "./node_modules/@lumino/algorithm/types/sort.d.ts",
+        "./node_modules/@lumino/algorithm/types/stride.d.ts",
+        "./node_modules/@lumino/algorithm/types/string.d.ts",
+        "./node_modules/@lumino/algorithm/types/take.d.ts",
+        "./node_modules/@lumino/algorithm/types/zip.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/singletonlayout.d.ts": [
         "./node_modules/@lumino/algorithm/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/splitlayout.d.ts": [
+      "./node_modules/@lumino/widgets/types/gridlayout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/splitpanel.d.ts": [
+      "./node_modules/@lumino/widgets/types/dockpanel.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
         "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/panel.d.ts",
-        "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/docklayout.d.ts",
+        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/docklayout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
+        "./node_modules/@lumino/widgets/types/tabbar.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/panellayout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/stackedlayout.d.ts": [
@@ -4941,22 +4340,42 @@
         "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/tabbar.d.ts": [
-        "./node_modules/@lumino/messaging/types/index.d.ts",
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/title.d.ts",
-        "./node_modules/@lumino/widgets/types/widget.d.ts"
-      ],
       "./node_modules/@lumino/widgets/types/tabpanel.d.ts": [
         "./node_modules/@lumino/signaling/types/index.d.ts",
         "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
         "./node_modules/@lumino/widgets/types/tabbar.d.ts",
         "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
-      "./node_modules/@lumino/widgets/types/title.d.ts": [
-        "./node_modules/@lumino/signaling/types/index.d.ts",
-        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      "./node_modules/@lumino/widgets/types/splitlayout.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/splitpanel.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/panel.d.ts",
+        "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/panel.d.ts": [
+        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/boxpanel.d.ts": [
+        "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
+        "./node_modules/@lumino/widgets/types/panel.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/boxlayout.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/layout.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
       ],
       "./node_modules/@lumino/widgets/types/widget.d.ts": [
         "./node_modules/@lumino/algorithm/types/index.d.ts",
@@ -4966,53 +4385,1162 @@
         "./node_modules/@lumino/widgets/types/layout.d.ts",
         "./node_modules/@lumino/widgets/types/title.d.ts"
       ],
+      "./node_modules/@lumino/widgets/types/scrollbar.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/focustracker.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/tabbar.d.ts": [
+        "./node_modules/@lumino/messaging/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@lumino/widgets/types/title.d.ts",
+        "./node_modules/@lumino/widgets/types/widget.d.ts"
+      ],
+      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@lumino/disposable/types/index.d.ts": [
+        "./node_modules/@lumino/algorithm/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts": [
+        "./node_modules/@lumino/disposable/types/index.d.ts",
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/zip.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/take.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/stride.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/sort.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/retro.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/repeat.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/reduce.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/range.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/map.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/find.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/filter.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/enumerate.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/empty.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@lumino/algorithm/types/chain.d.ts": [
+        "./node_modules/@lumino/algorithm/types/iter.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts",
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts"
+      ],
+      "./node_modules/@lumino/widgets/types/title.d.ts": [
+        "./node_modules/@lumino/signaling/types/index.d.ts",
+        "./node_modules/@lumino/virtualdom/types/index.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
+      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts": [
+        "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts"
+      ],
       "./node_modules/@types/react/index.d.ts": [
+        "./node_modules/@types/react/node_modules/csstype/index.d.ts",
         "./node_modules/@types/prop-types/index.d.ts",
-        "./node_modules/@types/react/global.d.ts",
-        "./node_modules/csstype/index.d.ts"
+        "./node_modules/@types/react/global.d.ts"
+      ],
+      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts": [
+        "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts": [
+        "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/slider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/rangeslider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/inputgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/formgroup.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/fileinput.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controls.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/forms/controlgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/editable-text/editabletext.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/drawer/drawer.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts": [
+        "./node_modules/popper.js/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts": [
+        "./node_modules/@types/react/index.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts": [
+        "./node_modules/@types/react/index.d.ts"
       ],
       "./node_modules/typestyle/lib/types.d.ts": [
         "./node_modules/csstype/index.d.ts"
       ],
-      "./src/aws_glue_databrew_extension.ts": [
-        "./node_modules/@jupyterlab/application/lib/index.d.ts",
-        "./node_modules/@lumino/commands/types/index.d.ts",
-        "./node_modules/@lumino/widgets/types/index.d.ts"
+      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts": [
+        "./node_modules/typestyle/lib/types.d.ts"
       ],
-      "./src/index.ts": [
-        "./node_modules/@jupyterlab/application/lib/index.d.ts"
+      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts": [
+        "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
+        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts"
+      ],
+      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts": [
+        "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts"
+      ],
+      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts": [
+        "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
+        "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/index.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/boxengine.d.ts",
+        "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts",
+        "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/docklayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/focustracker.d.ts",
+        "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menubar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/menubar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/docklayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/docklayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/tabbar.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/menu.d.ts": [
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts": [
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/menu.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/commands/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts": [
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/layout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/panellayout.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/panel.d.ts": [
+        "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/widget.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/messaging/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+        "./node_modules/@phosphor/widgets/lib/title.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/focustracker.d.ts": [
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts",
+        "./node_modules/@phosphor/widgets/lib/widget.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/index.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/array.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/chain.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/empty.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/filter.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/find.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/map.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/range.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/reduce.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/repeat.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/retro.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/sort.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/stride.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/string.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/take.d.ts",
+        "./node_modules/@phosphor/algorithm/lib/zip.d.ts"
+      ],
+      "./node_modules/@phosphor/disposable/lib/index.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/commands/lib/index.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+        "./node_modules/@phosphor/disposable/lib/index.d.ts",
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/zip.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/take.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/stride.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/sort.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/retro.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/repeat.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/reduce.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/range.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/map.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/find.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/filter.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/empty.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/algorithm/lib/chain.d.ts": [
+        "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
+      ],
+      "./node_modules/@phosphor/widgets/lib/title.d.ts": [
+        "./node_modules/@phosphor/signaling/lib/index.d.ts"
+      ],
+      "./node_modules/@phosphor/coreutils/lib/index.d.ts": [
+        "./node_modules/@phosphor/coreutils/lib/json.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/mime.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/promise.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/random.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/token.d.ts",
+        "./node_modules/@phosphor/coreutils/lib/uuid.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [
+      "./node_modules/@lumino/coreutils/types/json.d.ts",
+      "./node_modules/@lumino/coreutils/types/mime.d.ts",
+      "./node_modules/@lumino/coreutils/types/promise.d.ts",
+      "./node_modules/@lumino/coreutils/types/random.d.ts",
+      "./node_modules/@lumino/coreutils/types/token.d.ts",
+      "./node_modules/@lumino/coreutils/types/uuid.d.ts",
+      "./node_modules/@lumino/coreutils/types/index.d.ts",
+      "./node_modules/@lumino/algorithm/types/array.d.ts",
+      "./node_modules/@lumino/algorithm/types/iter.d.ts",
+      "./node_modules/@lumino/algorithm/types/chain.d.ts",
+      "./node_modules/@lumino/algorithm/types/empty.d.ts",
+      "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
+      "./node_modules/@lumino/algorithm/types/filter.d.ts",
+      "./node_modules/@lumino/algorithm/types/find.d.ts",
+      "./node_modules/@lumino/algorithm/types/map.d.ts",
+      "./node_modules/@lumino/algorithm/types/range.d.ts",
+      "./node_modules/@lumino/algorithm/types/reduce.d.ts",
+      "./node_modules/@lumino/algorithm/types/repeat.d.ts",
+      "./node_modules/@lumino/algorithm/types/retro.d.ts",
+      "./node_modules/@lumino/algorithm/types/sort.d.ts",
+      "./node_modules/@lumino/algorithm/types/stride.d.ts",
+      "./node_modules/@lumino/algorithm/types/string.d.ts",
+      "./node_modules/@lumino/algorithm/types/take.d.ts",
+      "./node_modules/@lumino/algorithm/types/zip.d.ts",
+      "./node_modules/@lumino/algorithm/types/index.d.ts",
+      "./node_modules/@lumino/signaling/types/index.d.ts",
+      "./node_modules/@lumino/disposable/types/index.d.ts",
+      "./node_modules/@lumino/virtualdom/types/index.d.ts",
+      "./node_modules/@lumino/commands/types/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
+      "./node_modules/@lumino/messaging/types/index.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
+      "./node_modules/@jupyterlab/observables/lib/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
+      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
+      "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
+      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
+      "./node_modules/@lumino/polling/types/poll.d.ts",
+      "./node_modules/@lumino/polling/types/ratelimiter.d.ts",
+      "./node_modules/@lumino/polling/types/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts",
+      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
+      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
+      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
+      "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
+      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
+      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
+      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
+      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
+      "./node_modules/@jupyterlab/services/lib/manager.d.ts",
+      "./node_modules/@jupyterlab/services/lib/index.d.ts",
+      "./node_modules/@jupyterlab/application/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts",
+      "./node_modules/@lumino/widgets/types/boxengine.d.ts",
+      "./node_modules/@lumino/widgets/types/title.d.ts",
+      "./node_modules/@lumino/widgets/types/widget.d.ts",
+      "./node_modules/@lumino/widgets/types/layout.d.ts",
+      "./node_modules/@lumino/widgets/types/panellayout.d.ts",
+      "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
+      "./node_modules/@lumino/widgets/types/panel.d.ts",
+      "./node_modules/@lumino/widgets/types/boxpanel.d.ts",
+      "./node_modules/@lumino/widgets/types/commandpalette.d.ts",
+      "./node_modules/@lumino/widgets/types/menu.d.ts",
+      "./node_modules/@lumino/widgets/types/contextmenu.d.ts",
+      "./node_modules/@lumino/widgets/types/tabbar.d.ts",
+      "./node_modules/@lumino/widgets/types/docklayout.d.ts",
+      "./node_modules/@lumino/widgets/types/dockpanel.d.ts",
+      "./node_modules/@lumino/widgets/types/focustracker.d.ts",
+      "./node_modules/@lumino/widgets/types/gridlayout.d.ts",
+      "./node_modules/@lumino/widgets/types/menubar.d.ts",
+      "./node_modules/@lumino/widgets/types/scrollbar.d.ts",
+      "./node_modules/@lumino/widgets/types/singletonlayout.d.ts",
+      "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
+      "./node_modules/@lumino/widgets/types/splitpanel.d.ts",
+      "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
+      "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
+      "./node_modules/@lumino/widgets/types/tabpanel.d.ts",
+      "./node_modules/@lumino/widgets/types/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts",
+      "./node_modules/@types/react/global.d.ts",
+      "./node_modules/@types/react/node_modules/csstype/index.d.ts",
+      "./node_modules/@types/prop-types/index.d.ts",
+      "./node_modules/@types/react/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/domutils.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/hoverbox.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts",
+      "./node_modules/csstype/index.d.ts",
+      "./node_modules/typestyle/lib/types.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractcomponent2.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/abstractpurecomponent2.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/alignment.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/boundary.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/colors.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/constructor.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/elevation.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/intent.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/position.d.ts",
+      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
+      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
+      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts",
+      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
+      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/props.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/common/refs.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/common/classes.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/common/keys.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/compareutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/domutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/functionutils.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/jsutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/reactutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/common/utils/safeinvokemember.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/common/utils/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/common/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/components/button/abstractbutton.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/components/button/buttons.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/components/collapse/collapse.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
       "./node_modules/@blueprintjs/core/lib/cjs/components/forms/inputgroup.d.ts",
-      "./node_modules/@blueprintjs/core/lib/cjs/components/icon/icon.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/accessibility/focusstylemanager.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/accessibility/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractcomponent.d.ts",
@@ -5021,36 +5549,42 @@
       "./node_modules/@blueprintjs/core/lib/esm/common/abstractpurecomponent2.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/alignment.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/boundary.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/colors.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/configuredom4.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/constructor.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/elevation.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/refs.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/props.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/classes.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/keys.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/compareutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/domutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/functionutils.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/jsutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/reactutils.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/common/utils/safeinvokemember.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/utils/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/configuredom4.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/alert/alert.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumb.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
+      "./node_modules/popper.js/index.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/breadcrumbs/breadcrumbs.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/button/abstractbutton.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/button/buttons.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/button/buttongroup.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/callout/callout.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/card/card.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/collapse/collapse.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/collapsible-list/collapsiblelist.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenu.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/context-menu/contextmenutarget.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/dialog/dialog.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/divider/divider.d.ts",
@@ -5064,36 +5598,32 @@
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/numericinput.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/radiogroup.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/forms/textarea.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/html-select/htmlselect.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/html-table/htmltable.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/html/html.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/icon/icon.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystypes.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeys.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkey.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/keycombo.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeyparser.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysevents.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeystarget.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/hotkeysdialog.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/hotkeys/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/menu/menudivider.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menuitem.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/menu/menu.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbardivider.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbargroup.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbarheading.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/navbar/navbar.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/non-ideal-state/nonidealstate.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/overflow-list/overflowlist.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/overlay/overlay.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelprops.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/panel-stack/panelstack.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popover.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/popover/popoversharedprops.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/common/context.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/portal/portal.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/progress-bar/progressbar.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizeobservertypes.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/resize-sensor/resizesensor.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/handleprops.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/slider/multislider.d.ts",
@@ -5102,247 +5632,160 @@
       "./node_modules/@blueprintjs/core/lib/esm/components/spinner/spinner.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tab.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/tabs/tabs.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/tag/tag.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/text/text.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/tag-input/taginput.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/toast/toast.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/toast/toaster.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/tooltip/tooltip.d.ts",
-      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/components/tree/treenode.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/tree/tree.d.ts",
+      "./node_modules/@blueprintjs/core/lib/esm/components/index.d.ts",
       "./node_modules/@blueprintjs/core/lib/esm/index.d.ts",
-      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconcontents.d.ts",
-      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconnames.d.ts",
-      "./node_modules/@blueprintjs/icons/lib/esm/generated/iconsvgpaths.d.ts",
-      "./node_modules/@blueprintjs/icons/lib/esm/iconname.d.ts",
-      "./node_modules/@blueprintjs/icons/lib/esm/index.d.ts",
       "./node_modules/@blueprintjs/select/lib/cjs/common/classes.d.ts",
-      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
+      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
       "./node_modules/@blueprintjs/select/lib/cjs/common/itemlistrenderer.d.ts",
       "./node_modules/@blueprintjs/select/lib/cjs/common/itemrenderer.d.ts",
-      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
-      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsutils.d.ts",
       "./node_modules/@blueprintjs/select/lib/cjs/common/predicate.d.ts",
+      "./node_modules/@blueprintjs/select/lib/cjs/common/listitemsprops.d.ts",
+      "./node_modules/@blueprintjs/select/lib/cjs/common/index.d.ts",
       "./node_modules/@blueprintjs/select/lib/cjs/components/select/select.d.ts",
-      "./node_modules/@jupyterlab/application/lib/connectionlost.d.ts",
+      "./node_modules/@blueprintjs/core/lib/cjs/components/forms/controls.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts",
+      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/sanitizer.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/styling.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts",
+      "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
+      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
+      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
+      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
+      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts",
+      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
+      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
+      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
+      "./node_modules/@lumino/application/types/index.d.ts",
       "./node_modules/@jupyterlab/application/lib/frontend.d.ts",
-      "./node_modules/@jupyterlab/application/lib/index.d.ts",
+      "./node_modules/@jupyterlab/application/lib/shell.d.ts",
+      "./node_modules/@jupyterlab/application/lib/status.d.ts",
       "./node_modules/@jupyterlab/application/lib/lab.d.ts",
       "./node_modules/@jupyterlab/application/lib/layoutrestorer.d.ts",
       "./node_modules/@jupyterlab/application/lib/mimerenderers.d.ts",
       "./node_modules/@jupyterlab/application/lib/router.d.ts",
-      "./node_modules/@jupyterlab/application/lib/shell.d.ts",
-      "./node_modules/@jupyterlab/application/lib/status.d.ts",
-      "./node_modules/@jupyterlab/application/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/clipboard.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/collapse.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/commandlinker.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/commandpalette.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/dialog.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/domutils.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/hoverbox.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/iframe.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/inputdialog.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/mainareawidget.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/printing.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/sanitizer.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/sessioncontext.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/spinner.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/splash.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/styling.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/thememanager.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/toolbar.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/vdom.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/widgettracker.d.ts",
-      "./node_modules/@jupyterlab/apputils/lib/windowresolver.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/editor.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/factory.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/index.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/jsoneditor.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/mimetype.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/codeeditor/lib/widget.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/activitymonitor.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/index.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/interfaces.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/markdowncodeblocks.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/pageconfig.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/path.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/text.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/time.d.ts",
-      "./node_modules/@jupyterlab/coreutils/lib/url.d.ts",
-      "./node_modules/@jupyterlab/docregistry/lib/context.d.ts",
-      "./node_modules/@jupyterlab/docregistry/lib/default.d.ts",
-      "./node_modules/@jupyterlab/docregistry/lib/index.d.ts",
-      "./node_modules/@jupyterlab/docregistry/lib/mimedocument.d.ts",
-      "./node_modules/@jupyterlab/docregistry/lib/registry.d.ts",
+      "./node_modules/@jupyterlab/application/lib/index.d.ts",
       "./node_modules/@jupyterlab/launcher/lib/index.d.ts",
-      "./node_modules/@jupyterlab/nbformat/lib/index.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/index.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/modeldb.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/observablejson.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/observablelist.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/observablemap.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/observablestring.d.ts",
-      "./node_modules/@jupyterlab/observables/lib/undoablelist.d.ts",
-      "./node_modules/@jupyterlab/rendermime-interfaces/lib/index.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/attachmentmodel.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/factories.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/index.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/latex.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/mimemodel.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/outputmodel.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/registry.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/renderers.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/rendermime/lib/widgets.d.ts",
-      "./node_modules/@jupyterlab/services/lib/basemanager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/builder/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/config/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/contents/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernel/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernel/kernel.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernel/manager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernel/messages.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernel/restapi.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernelspec/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernelspec/kernelspec.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernelspec/manager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/kernelspec/restapi.d.ts",
-      "./node_modules/@jupyterlab/services/lib/manager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/nbconvert/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/serverconnection.d.ts",
-      "./node_modules/@jupyterlab/services/lib/session/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/session/manager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/session/restapi.d.ts",
-      "./node_modules/@jupyterlab/services/lib/session/session.d.ts",
-      "./node_modules/@jupyterlab/services/lib/setting/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/terminal/index.d.ts",
-      "./node_modules/@jupyterlab/services/lib/terminal/manager.d.ts",
-      "./node_modules/@jupyterlab/services/lib/terminal/restapi.d.ts",
-      "./node_modules/@jupyterlab/services/lib/terminal/terminal.d.ts",
-      "./node_modules/@jupyterlab/services/lib/workspace/index.d.ts",
-      "./node_modules/@jupyterlab/settingregistry/lib/index.d.ts",
-      "./node_modules/@jupyterlab/settingregistry/lib/settingregistry.d.ts",
-      "./node_modules/@jupyterlab/settingregistry/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/dataconnector.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/index.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/interfaces.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/restorablepool.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/statedb.d.ts",
-      "./node_modules/@jupyterlab/statedb/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/blueprint.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/components/htmlselect.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/components/index.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/components/interface.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/iconimports.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/index.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/labicon.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/commandpalettesvg.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/index.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/menusvg.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/icon/widgets/tabbarsvg.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/index.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/style/icon.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/style/index.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/tokens.d.ts",
-      "./node_modules/@jupyterlab/ui-components/lib/utils.d.ts",
-      "./node_modules/@lumino/algorithm/types/array.d.ts",
-      "./node_modules/@lumino/algorithm/types/chain.d.ts",
-      "./node_modules/@lumino/algorithm/types/empty.d.ts",
-      "./node_modules/@lumino/algorithm/types/enumerate.d.ts",
-      "./node_modules/@lumino/algorithm/types/filter.d.ts",
-      "./node_modules/@lumino/algorithm/types/find.d.ts",
-      "./node_modules/@lumino/algorithm/types/index.d.ts",
-      "./node_modules/@lumino/algorithm/types/iter.d.ts",
-      "./node_modules/@lumino/algorithm/types/map.d.ts",
-      "./node_modules/@lumino/algorithm/types/range.d.ts",
-      "./node_modules/@lumino/algorithm/types/reduce.d.ts",
-      "./node_modules/@lumino/algorithm/types/repeat.d.ts",
-      "./node_modules/@lumino/algorithm/types/retro.d.ts",
-      "./node_modules/@lumino/algorithm/types/sort.d.ts",
-      "./node_modules/@lumino/algorithm/types/stride.d.ts",
-      "./node_modules/@lumino/algorithm/types/string.d.ts",
-      "./node_modules/@lumino/algorithm/types/take.d.ts",
-      "./node_modules/@lumino/algorithm/types/zip.d.ts",
-      "./node_modules/@lumino/application/types/index.d.ts",
-      "./node_modules/@lumino/commands/types/index.d.ts",
-      "./node_modules/@lumino/coreutils/types/index.d.ts",
-      "./node_modules/@lumino/coreutils/types/json.d.ts",
-      "./node_modules/@lumino/coreutils/types/mime.d.ts",
-      "./node_modules/@lumino/coreutils/types/promise.d.ts",
-      "./node_modules/@lumino/coreutils/types/random.d.ts",
-      "./node_modules/@lumino/coreutils/types/token.d.ts",
-      "./node_modules/@lumino/coreutils/types/uuid.d.ts",
-      "./node_modules/@lumino/disposable/types/index.d.ts",
-      "./node_modules/@lumino/messaging/types/index.d.ts",
-      "./node_modules/@lumino/polling/types/index.d.ts",
-      "./node_modules/@lumino/polling/types/poll.d.ts",
-      "./node_modules/@lumino/polling/types/ratelimiter.d.ts",
-      "./node_modules/@lumino/signaling/types/index.d.ts",
-      "./node_modules/@lumino/virtualdom/types/index.d.ts",
-      "./node_modules/@lumino/widgets/types/boxengine.d.ts",
-      "./node_modules/@lumino/widgets/types/boxlayout.d.ts",
-      "./node_modules/@lumino/widgets/types/boxpanel.d.ts",
-      "./node_modules/@lumino/widgets/types/commandpalette.d.ts",
-      "./node_modules/@lumino/widgets/types/contextmenu.d.ts",
-      "./node_modules/@lumino/widgets/types/docklayout.d.ts",
-      "./node_modules/@lumino/widgets/types/dockpanel.d.ts",
-      "./node_modules/@lumino/widgets/types/focustracker.d.ts",
-      "./node_modules/@lumino/widgets/types/gridlayout.d.ts",
-      "./node_modules/@lumino/widgets/types/index.d.ts",
-      "./node_modules/@lumino/widgets/types/layout.d.ts",
-      "./node_modules/@lumino/widgets/types/menu.d.ts",
-      "./node_modules/@lumino/widgets/types/menubar.d.ts",
-      "./node_modules/@lumino/widgets/types/panel.d.ts",
-      "./node_modules/@lumino/widgets/types/panellayout.d.ts",
-      "./node_modules/@lumino/widgets/types/scrollbar.d.ts",
-      "./node_modules/@lumino/widgets/types/singletonlayout.d.ts",
-      "./node_modules/@lumino/widgets/types/splitlayout.d.ts",
-      "./node_modules/@lumino/widgets/types/splitpanel.d.ts",
-      "./node_modules/@lumino/widgets/types/stackedlayout.d.ts",
-      "./node_modules/@lumino/widgets/types/stackedpanel.d.ts",
-      "./node_modules/@lumino/widgets/types/tabbar.d.ts",
-      "./node_modules/@lumino/widgets/types/tabpanel.d.ts",
-      "./node_modules/@lumino/widgets/types/title.d.ts",
-      "./node_modules/@lumino/widgets/types/widget.d.ts",
-      "./node_modules/@types/prop-types/index.d.ts",
-      "./node_modules/@types/react/global.d.ts",
-      "./node_modules/@types/react/index.d.ts",
-      "./node_modules/csstype/index.d.ts",
-      "./node_modules/popper.js/index.d.ts",
-      "./node_modules/typestyle/lib/types.d.ts",
+      "./src/constants.ts",
+      "./node_modules/@phosphor/widgets/lib/boxengine.d.ts",
+      "./node_modules/@phosphor/messaging/lib/index.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/array.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/iter.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/chain.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/empty.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/enumerate.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/filter.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/find.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/map.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/range.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/reduce.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/repeat.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/retro.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/sort.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/stride.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/string.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/take.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/zip.d.ts",
+      "./node_modules/@phosphor/algorithm/lib/index.d.ts",
+      "./node_modules/@phosphor/signaling/lib/index.d.ts",
+      "./node_modules/@phosphor/disposable/lib/index.d.ts",
+      "./node_modules/@phosphor/widgets/lib/title.d.ts",
+      "./node_modules/@phosphor/widgets/lib/widget.d.ts",
+      "./node_modules/@phosphor/widgets/lib/layout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/panellayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/panel.d.ts",
+      "./node_modules/@phosphor/widgets/lib/boxpanel.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/json.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/mime.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/promise.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/random.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/token.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/uuid.d.ts",
+      "./node_modules/@phosphor/coreutils/lib/index.d.ts",
+      "./node_modules/@phosphor/commands/lib/index.d.ts",
+      "./node_modules/@phosphor/virtualdom/lib/index.d.ts",
+      "./node_modules/@phosphor/widgets/lib/commandpalette.d.ts",
+      "./node_modules/@phosphor/widgets/lib/menu.d.ts",
+      "./node_modules/@phosphor/widgets/lib/contextmenu.d.ts",
+      "./node_modules/@phosphor/widgets/lib/tabbar.d.ts",
+      "./node_modules/@phosphor/widgets/lib/docklayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/dockpanel.d.ts",
+      "./node_modules/@phosphor/widgets/lib/focustracker.d.ts",
+      "./node_modules/@phosphor/widgets/lib/gridlayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/menubar.d.ts",
+      "./node_modules/@phosphor/widgets/lib/scrollbar.d.ts",
+      "./node_modules/@phosphor/widgets/lib/singletonlayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/splitlayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/splitpanel.d.ts",
+      "./node_modules/@phosphor/widgets/lib/stackedlayout.d.ts",
+      "./node_modules/@phosphor/widgets/lib/stackedpanel.d.ts",
+      "./node_modules/@phosphor/widgets/lib/tabpanel.d.ts",
+      "./node_modules/@phosphor/widgets/lib/index.d.ts",
+      "./src/leftsidelauncher.ts",
+      "./src/mainlauncher.ts",
       "./src/aws_glue_databrew_extension.ts",
       "./src/index.ts",
       "./src/svg_icons.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.dom.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.dom.iterable.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.collection.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.core.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.generator.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.promise.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.proxy.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.reflect.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.symbol.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2016.array.include.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2016.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.full.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.intl.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.object.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.string.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.es5.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.scripthost.d.ts",
-      "../../../../usr/local/lib/node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+      "./node_modules/typescript/lib/lib.es2015.d.ts",
+      "./node_modules/typescript/lib/lib.es2016.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.full.d.ts",
+      "./node_modules/typescript/lib/lib.es5.d.ts",
+      "./node_modules/typescript/lib/lib.dom.d.ts",
+      "./node_modules/typescript/lib/lib.dom.iterable.d.ts",
+      "./node_modules/typescript/lib/lib.webworker.importscripts.d.ts",
+      "./node_modules/typescript/lib/lib.scripthost.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.core.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.collection.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.generator.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.promise.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.proxy.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.reflect.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.symbol.d.ts",
+      "./node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+      "./node_modules/typescript/lib/lib.es2016.array.include.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.object.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.string.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.intl.d.ts",
+      "./node_modules/typescript/lib/lib.es2017.typedarrays.d.ts"
     ]
   },
-  "version": "4.0.5"
+  "version": "3.7.5"
 }


### PR DESCRIPTION
Added support for jupyter 1.2.x

- Depend on [@phosphor/widget](https://www.npmjs.com/package/@phosphor/widgets?activeTab=versions) and [@lumino/widget](https://www.npmjs.com/package/@lumino/widgets?activeTab=versions) libraries
- Conditionally use widgets based on local jupyter lab version using this [version api](https://jupyterlab.github.io/jupyterlab/classes/_application_src_index_.jupyterfrontend.html#version)
- Remove use of [LabIcon](https://jupyterlab.github.io/jupyterlab/classes/_ui_components_src_index_.labicon.html) and use css approach to show launcher icon