### PR TITLE
Allow dynamic aws region settings

### DIFF
--- a/aws_glue_databrew_jupyter_extension/__init__.py
+++ b/aws_glue_databrew_jupyter_extension/__init__.py
@@ -1,6 +1,16 @@
+from .aws_config_handler import AWSConfigHandler
+
 def _jupyter_server_extension_paths():
-    return [{"module": "aws_jupyter_proxy"}]
+    return [{"module": "aws_glue_databrew_jupyter_extension"}]
 
 
 def _jupyter_nbextension_paths():
     return []
+
+
+def load_jupyter_server_extension(nb_server_app):
+    web_app = nb_server_app.web_app
+    host_pattern = '.*$'
+    web_app.add_handlers(host_pattern, [
+        ('/api/aws-config', AWSConfigHandler),
+    ])

--- a/aws_glue_databrew_jupyter_extension/aws_config_handler.py
+++ b/aws_glue_databrew_jupyter_extension/aws_config_handler.py
@@ -1,0 +1,20 @@
+from notebook.base.handlers import IPythonHandler, utcnow
+import json
+from boto3 import session
+
+class AWSConfigHandler(IPythonHandler):
+    def get(self):
+        response = {}
+
+        self.set_header("Content-Type", "application/json")
+        if self.request.uri == '/api/aws-config':
+            aws_region = self._get_aws_region()
+
+            response = {
+             "region" : aws_region
+            }
+            self.write(json.dumps(response))
+
+    def _get_aws_region(self):
+        aws_session = session.Session()
+        return aws_session.region_name or 'us-east-1'

--- a/aws_glue_databrew_jupyter_extension/etc/aws_glue_databrew_jupyter_extension.json
+++ b/aws_glue_databrew_jupyter_extension/etc/aws_glue_databrew_jupyter_extension.json
@@ -1,7 +1,7 @@
 {
   "NotebookApp": {
     "nbserver_extensions": {
-      "aws_jupyter_proxy": true
+      "aws_glue_databrew_jupyter_extension": true
     }
   }
 }

--- a/lib/MainLauncher.d.ts
+++ b/lib/MainLauncher.d.ts
@@ -21,5 +21,5 @@ export declare class LuminoMainLauncher extends LuminoWidget {
     cssPath: string;
 }
 export declare class MainLauncher {
-    static create(version: number, cssPath: string): PhosphorMainLauncher | LuminoMainLauncher;
+    static create(version: number, cssPath: string, region: string): PhosphorMainLauncher | LuminoMainLauncher;
 }

--- a/lib/MainLauncher.js
+++ b/lib/MainLauncher.js
@@ -5,7 +5,7 @@ export class PhosphorMainLauncher extends PhosphorWidget {
 export class LuminoMainLauncher extends LuminoWidget {
 }
 export class MainLauncher {
-    static create(version, cssPath) {
+    static create(version, cssPath, region) {
         const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
         widget.cssPath = cssPath;
         widget.id = 'aws_glue_databrew_jupyter';
@@ -19,8 +19,9 @@ export class MainLauncher {
           <meta charset="UTF-8">
           <meta name="awsc-lang" content="en">
           <meta name="aws-glue-databrew-jupyter" content="true">
+          <meta id="aws-glue-databrew-jupyter-region" name="aws-region" content="${region}">
           <title>AWS</title>
-          <link rel="stylesheet" href=` + cssPath + `>
+          <link rel="stylesheet" href="${cssPath}">
           <style>
             .loader {
               display: inline-block;

--- a/lib/aws_glue_databrew_extension.d.ts
+++ b/lib/aws_glue_databrew_extension.d.ts
@@ -2,4 +2,4 @@ import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 /**
  * Initialize the console widget extension
  */
-export declare const initiateExtension: (getPaths: () => Promise<string[]>) => JupyterFrontEndPlugin<void>;
+export declare const initiateExtension: () => JupyterFrontEndPlugin<void>;

--- a/lib/aws_glue_databrew_extension.js
+++ b/lib/aws_glue_databrew_extension.js
@@ -1,19 +1,22 @@
 import { ILayoutRestorer, } from '@jupyterlab/application';
 import { ICommandPalette, } from '@jupyterlab/apputils';
 import { ILauncher, } from '@jupyterlab/launcher';
-import { GLUE_DATABREW_RENDER } from './constants';
+import { getAWSConfig, getPrefix } from './client';
+import { CONTENT_PREFIX, GLUE_DATABREW_RENDER, jsFileName, styleFileName } from './constants';
 import { LeftSideLauncher, } from './LeftSideLauncher';
 import { MainLauncher, } from './MainLauncher';
 const getAppVersion = (app) => Number(app.version.split('.')[0]);
 /**
  * Initialize the console widget extension
  */
-export const initiateExtension = (getPaths) => {
+export const initiateExtension = () => {
     const activate = async (app, palette, restorer, launcher) => {
         const version = getAppVersion(app);
-        // Declare a widget variable
-        const [jsPath, cssPath] = await getPaths();
-        const consoleWidget = MainLauncher.create(version, cssPath);
+        const prefix = await getPrefix();
+        const jsPath = `${CONTENT_PREFIX}/${prefix}/${jsFileName}`;
+        const cssPath = `${CONTENT_PREFIX}/${prefix}/${styleFileName}`;
+        const { region } = await getAWSConfig();
+        const consoleWidget = MainLauncher.create(version, cssPath, region);
         app.commands.addCommand(GLUE_DATABREW_RENDER, {
             label: 'Launch AWS Glue DataBrew',
             icon: 'jp-databrew-logo',

--- a/lib/client.d.ts
+++ b/lib/client.d.ts
@@ -1,0 +1,5 @@
+import { AWSConfig } from './types';
+export declare const getPrefix: () => Promise<string>;
+export declare const getAWSConfig: () => Promise<AWSConfig>;
+export declare const get: (path: string) => Promise<any>;
+export declare const request: (req: Request) => Promise<any>;

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,21 @@
+import { PREFIX_URL } from './constants';
+export const getPrefix = async () => {
+    const data = await get(PREFIX_URL);
+    return data.prefix;
+};
+export const getAWSConfig = () => {
+    return get('/api/aws-config');
+};
+export const get = (path) => {
+    const options = { method: 'get' };
+    return request(new Request(path, options));
+};
+export const request = async (req) => {
+    const res = await fetch(req);
+    const text = await res.text();
+    const data = text && JSON.parse(text);
+    if (!res.ok) {
+        throw new Error((data && data.message) || res.statusText);
+    }
+    return data;
+};

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,1 +1,6 @@
 export declare const GLUE_DATABREW_RENDER = "gluedatabrew:render";
+export declare const CLOUDFRONT_HOST = "https://dc69wn9dwut4o.cloudfront.net";
+export declare const CONTENT_PREFIX: string;
+export declare const PREFIX_URL: string;
+export declare const jsFileName = "main.js";
+export declare const styleFileName = "styles.css";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,1 +1,6 @@
 export const GLUE_DATABREW_RENDER = 'gluedatabrew:render';
+export const CLOUDFRONT_HOST = 'https://dc69wn9dwut4o.cloudfront.net';
+export const CONTENT_PREFIX = CLOUDFRONT_HOST + '/content';
+export const PREFIX_URL = CLOUDFRONT_HOST + '/prefixes/main';
+export const jsFileName = 'main.js';
+export const styleFileName = 'styles.css';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,3 @@
 import { initiateExtension } from './aws_glue_databrew_extension';
-// these are jupyter_beta assets
-const CLOUDFRONT_HOST = 'https://dc69wn9dwut4o.cloudfront.net';
-const CONTENT_PREFIX = CLOUDFRONT_HOST + '/content';
-const PREFIX_URL = CLOUDFRONT_HOST + '/prefixes/main';
-const jsFileName = 'main.js';
-const styleFileName = 'styles.css';
-const getPaths = async () => {
-    const prefix = await getPrefix();
-    return [
-        `${CONTENT_PREFIX}/${prefix}/${jsFileName}`,
-        `${CONTENT_PREFIX}/${prefix}/${styleFileName}`,
-    ];
-};
-const getPrefix = async () => {
-    const response = await fetch(PREFIX_URL);
-    const json = await response.json();
-    return json && json.prefix.toString();
-};
-const extension = initiateExtension(getPaths);
+const extension = initiateExtension();
 export default extension;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,3 @@
+export interface AWSConfig {
+    region: string;
+}

--- a/src/MainLauncher.ts
+++ b/src/MainLauncher.ts
@@ -29,7 +29,7 @@ export class LuminoMainLauncher extends LuminoWidget {
 }
 
 export class MainLauncher {
-  static create(version: number, cssPath: string) {
+  static create(version: number, cssPath: string, region: string) {
     const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
 
     widget.cssPath = cssPath;
@@ -47,8 +47,9 @@ export class MainLauncher {
           <meta charset="UTF-8">
           <meta name="awsc-lang" content="en">
           <meta name="aws-glue-databrew-jupyter" content="true">
+          <meta id="aws-glue-databrew-jupyter-region" name="aws-region" content="${region}">
           <title>AWS</title>
-          <link rel="stylesheet" href=` + cssPath + `>
+          <link rel="stylesheet" href="${cssPath}">
           <style>
             .loader {
               display: inline-block;

--- a/src/aws_glue_databrew_extension.ts
+++ b/src/aws_glue_databrew_extension.ts
@@ -15,7 +15,15 @@ import {
 } from '@lumino/widgets';
 
 import {
-  GLUE_DATABREW_RENDER
+  getAWSConfig,
+  getPrefix
+} from './client';
+
+import {
+  CONTENT_PREFIX,
+  GLUE_DATABREW_RENDER,
+  jsFileName,
+  styleFileName
 } from './constants';
 
 import {
@@ -31,13 +39,17 @@ const getAppVersion = (app: JupyterFrontEnd) => Number(app.version.split('.')[0]
 /**
  * Initialize the console widget extension
  */
-export const initiateExtension = (getPaths: () => Promise<string[]>) => {
+export const initiateExtension = () => {
   const activate = async (app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer, launcher: ILauncher) => {
     const version = getAppVersion(app);
-    // Declare a widget variable
-    const [jsPath, cssPath] = await getPaths();
 
-    const consoleWidget = MainLauncher.create(version, cssPath);
+    const prefix = await getPrefix();
+    const jsPath = `${CONTENT_PREFIX}/${prefix}/${jsFileName}`;
+    const cssPath = `${CONTENT_PREFIX}/${prefix}/${styleFileName}`;
+    
+    const { region } = await getAWSConfig();
+
+    const consoleWidget = MainLauncher.create(version, cssPath, region);
 
     app.commands.addCommand(GLUE_DATABREW_RENDER, {
       label: 'Launch AWS Glue DataBrew',

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,26 @@
+import { PREFIX_URL } from './constants';
+import { AWSConfig } from './types';
+
+export const getPrefix = async (): Promise<string> => {
+  const data = await get(PREFIX_URL);
+  return data.prefix;
+};
+
+export const getAWSConfig = (): Promise<AWSConfig> => {
+  return get('/api/aws-config');
+};
+
+export const get = (path: string) => {
+  const options = { method: 'get' };
+  return request(new Request(path, options));
+};
+
+export const request = async (req: Request) => {
+  const res = await fetch(req);
+  const text = await res.text();
+  const data = text && JSON.parse(text);
+  if (!res.ok) {
+    throw new Error((data && data.message) || res.statusText);
+  }
+  return data;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,6 @@
 export const GLUE_DATABREW_RENDER = 'gluedatabrew:render';
+export const CLOUDFRONT_HOST = 'https://dc69wn9dwut4o.cloudfront.net';
+export const CONTENT_PREFIX = CLOUDFRONT_HOST + '/content';
+export const PREFIX_URL = CLOUDFRONT_HOST + '/prefixes/main';
+export const jsFileName = 'main.js';
+export const styleFileName = 'styles.css';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,5 @@
 import { initiateExtension } from './aws_glue_databrew_extension';
 
-// these are jupyter_beta assets
-const CLOUDFRONT_HOST = 'https://dc69wn9dwut4o.cloudfront.net';
-const CONTENT_PREFIX = CLOUDFRONT_HOST + '/content';
-const PREFIX_URL = CLOUDFRONT_HOST + '/prefixes/main';
-const jsFileName = 'main.js';
-const styleFileName = 'styles.css';
-
-const getPaths = async () => {
-  const prefix = await getPrefix();
-  return [
-    `${CONTENT_PREFIX}/${prefix}/${jsFileName}`,
-    `${CONTENT_PREFIX}/${prefix}/${styleFileName}`,
-  ]
-};
-
-const getPrefix = async () => {
-  const response = await fetch(PREFIX_URL);
-  const json = await response.json();
-  return json && json.prefix.toString();
-};
-
-
-const extension = initiateExtension(getPaths);
+const extension = initiateExtension();
 
 export default extension;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface AWSConfig {
+  region: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,9 +22,11 @@
   "include": [
     "src/index.ts",
     "src/aws_glue_databrew_extension.ts",
+    "src/client.ts",
     "src/MainLauncher.ts",
     "src/LeftSideLauncher.ts",
     "src/constants.ts",
+    "src/types.ts",
     "src/svg_icons.d.ts"
   ]
 }

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1430,8 +1430,16 @@
         "signature": "d9ac2d11a7feabbc00ab593796bbc3f84884803068a125b45666368b6f67dca3"
       },
       "./src/constants.ts": {
-        "version": "9a209e179860049eb4726eddf1598f4f0d4ed21634957b2a318ded4848391d05",
-        "signature": "87418576438b2534c414c5fbd227e48f18af4c88494cd2e566a58a1bf2f1b216"
+        "version": "2a76ec92041834567ccbe319040672f73b2228a2cb4b52e47936d73f407836c5",
+        "signature": "af633de24711d1a553b6ccc396f7389d4dfb46e5bd267706f47e6bb7b0518f6a"
+      },
+      "./src/types.ts": {
+        "version": "b3bf2a38b18b598e333d077f2c3ce1d9199a841bb972c13fc7952bd040a0c708",
+        "signature": "c96be80046d3d154ae3a668a2f0f76572c65cba026b881d1434b5f023a52627f"
+      },
+      "./src/client.ts": {
+        "version": "9828ecbfc7960385ae54d49f203736c41eea4bc7d138b95f2ac57b904fb7012d",
+        "signature": "44d98514808c97a80081e238ee4e9b3807b19f13d0047da73d7332b0e38dc439"
       },
       "./node_modules/@phosphor/widgets/lib/boxengine.d.ts": {
         "version": "518f0974b55341500d4234068f32fa9750c3d373f41edebbb99c47798b2d102b",
@@ -1654,19 +1662,19 @@
         "signature": "ce75ab9766be65e1b6837cba39ea25ebfbe25f431e0f97e1863743817fad2d91"
       },
       "./src/leftsidelauncher.ts": {
-        "version": "4aad8e64dd7e47561f78e1271ef72768c6b069186979cbada3f4d462a7bb7f4f",
+        "version": "c16d7266472abd363e17665c7b7263b4f0e1a69b558970093b1fe4621f7a70a4",
         "signature": "db2f5f64826f0304cf778d51b135c1bc8eb69289a5a8217106055ef1a752dbf1"
       },
       "./src/mainlauncher.ts": {
-        "version": "b2ed6cd82f44377c8ea2f6b97a5ff2af22828e9b350c3908850000d590c9d296",
-        "signature": "bc20ff78e9b1df162745ac36b63b928733e19b035a61cd4a509d8159dbc1d1e8"
+        "version": "2452078fe6918994f78f511d184815135d06b10737ca19ed5120c0afb4dcefb2",
+        "signature": "fd8fe6f9ebae12dbf948b378e35dc3e66a4ff2cfe824d5b24981df6a46d7d5eb"
       },
       "./src/aws_glue_databrew_extension.ts": {
-        "version": "cc3d045ce8a80d824f2b4080eac650d3f2f3dc80ff0241e31c574f93c423cf0f",
-        "signature": "eeb642b57a8891c39dca104f1ca10bbaff45d1fe7e3d0fb0632333dd32271eb6"
+        "version": "efc3e83cfc237e6730ca5c92ace63e4109672b5ac78ce1a7c9814d8981b6f075",
+        "signature": "674d457d34215b25157f7d13623c98619420036a08aa28a954d7cfa934871175"
       },
       "./src/index.ts": {
-        "version": "bafc391b4efa5a1a01be881b76eaedc0d522766a067215a8db6bafed9a039ba7",
+        "version": "79ca691283b0497326c729dd620a50e26b93e644e2512ea864b95bffc9c4eceb",
         "signature": "ba8cdf6e5e786fee2541e7a49f93e1afd52fcb2730ae95374fcaa2eebac6efe4"
       },
       "./src/svg_icons.d.ts": {
@@ -3272,6 +3280,10 @@
         "./node_modules/@lumino/widgets/types/index.d.ts",
         "./node_modules/@types/react/index.d.ts"
       ],
+      "./src/client.ts": [
+        "./src/constants.ts",
+        "./src/types.ts"
+      ],
       "./node_modules/@phosphor/algorithm/lib/chain.d.ts": [
         "./node_modules/@phosphor/algorithm/lib/iter.d.ts"
       ],
@@ -3526,6 +3538,7 @@
         "./node_modules/@jupyterlab/apputils/lib/index.d.ts",
         "./node_modules/@jupyterlab/launcher/lib/index.d.ts",
         "./node_modules/@lumino/widgets/types/index.d.ts",
+        "./src/client.ts",
         "./src/constants.ts",
         "./src/leftsidelauncher.ts",
         "./src/mainlauncher.ts"
@@ -5127,6 +5140,9 @@
         "./node_modules/@blueprintjs/core/lib/esm/common/intent.d.ts",
         "./node_modules/@blueprintjs/core/lib/esm/common/position.d.ts"
       ],
+      "./src/client.ts": [
+        "./src/types.ts"
+      ],
       "./node_modules/@phosphor/widgets/lib/index.d.ts": [
         "./node_modules/@phosphor/widgets/lib/boxengine.d.ts",
         "./node_modules/@phosphor/widgets/lib/boxlayout.d.ts",
@@ -5701,6 +5717,8 @@
       "./node_modules/@jupyterlab/application/lib/index.d.ts",
       "./node_modules/@jupyterlab/launcher/lib/index.d.ts",
       "./src/constants.ts",
+      "./src/types.ts",
+      "./src/client.ts",
       "./node_modules/@phosphor/widgets/lib/boxengine.d.ts",
       "./node_modules/@phosphor/messaging/lib/index.d.ts",
       "./node_modules/@phosphor/algorithm/lib/array.d.ts",


### PR DESCRIPTION
Allow dynamic aws region settings

* Added server extension exposing an api to get aws region config
* Server extension gets aws region config on machine running jupyter server, set using `aws configure region <region>`, using boto3
* Client extension calls server extension (via http request) to get aws region config and injects to dom with meta tag
* This meta tag is used to initialize aws client to specified region