### PR TITLE
Update DataBrew extension install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ This is an extension for Jupyter Lab that allows you to manage your AWS Glue Dat
 1. boto3 version 1.16.17 or greater
 1. botocore version 1.19.17 or greater
 1. configure the aws cli. https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
-1. jupyter lab version 2.x
+1. jupyter lab version 1.2 or 2.x
 
 ### Installation instructions for Jupyter Lab
 
 1. run `pip install aws-jupyter-proxy`
+1. run `jupyter serverextension enable --py aws_jupyter_proxy`
 1. Search for aws_glue_databrew_jupyter in the Jupyter Lab plugin store and click install
 
 ### Installation instructions for Amazon SageMaker Notebooks

--- a/SageMaker-Installation-Instructions.md
+++ b/SageMaker-Installation-Instructions.md
@@ -1,32 +1,24 @@
-### Ensuring permissions for your SageMaker role ###
+### Ensuring permissions for your SageMaker role
+
 Make sure to add the correct permissions to the role your SageMaker notebook runs with. A good place to start is by adding the 'AwsGlueDataBrewFullAccessPolicy' managed policy to the role, and then adding inline permissions allowing s3:GetObject and s3:PutObject for the bucket in which you would like to operate.
 
-### Installing the plugin ###
-1. Uninstall extensions that prevent us from upgrading the Jupyter environment
+### Installing the plugin
+
+1. Install dependencies
+
 ```
-jupyter labextension uninstall @jupyterlab/celltags;
-jupyter labextension uninstall @jupyterlab/git;
-jupyter labextension uninstall @jupyterlab/toc;
-```
-2. Upgrade Jupyter
-```
-conda install --yes -c conda-forge jupyterlab=2;
-```
-3. Install dependencies
-```
-pip install awscli -U;
-pip install botocore -U;
 pip install aws-jupyter-proxy;
 ```
 
-4. Install the extension and build Jupyter assets
+1. Install the extension and build Jupyter assets
 
 ```
 jupyter labextension install aws_glue_databrew_jupyter;
 jupyter lab build;
 ```
 
-5. Restart the Jupyter server
+1. Restart the Jupyter server
+
 ```
 sudo initctl restart jupyter-server --no-wait;
 ```


### PR DESCRIPTION
Update sagemaker install guide after jupyterlab 1.2 support

* Add command to manually enable aws-jupyter-proxy in case jupyter version doesn't do it automatically
* Removed steps to uninstall jupyter lab plugins
* Removed steps to upgrade jupyterlab to version 2