### PR TITLE
Fixed awsconfig api path

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,6 @@
 export const getAWSConfig = async (basePath) => {
     try {
-        const config = await get("/awsproxy/awsconfig");
+        const config = await get(`${basePath}awsproxy/awsconfig`);
         return {
             region: config.region,
         };

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@ import { AWSConfig } from "./types";
 
 export const getAWSConfig = async (basePath: string): Promise<AWSConfig> => {
   try {
-    const config = await get<AWSConfig>("/awsproxy/awsconfig");
+    const config = await get<AWSConfig>(`${basePath}awsproxy/awsconfig`);
     return {
       region: config.region,
     };

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1434,7 +1434,7 @@
         "signature": "9153563ec8445a492ffc79678a0be69473ad9c10db1a4804b20f6a7640aee454"
       },
       "./src/client.ts": {
-        "version": "5177ad1dfb89109c5e8ffd8ef7e3ae979c40e42ab591357ac5cb75326cf302f5",
+        "version": "cb897a1ca962acc559cea1b98fc53a6ffe27b6b3429ea9ac76d6b8c3239de354",
         "signature": "98e819b07021a75c61c3d8a6601f068b2fdb6eb227ada63cb085ec36824cd1b1"
       },
       "./src/subdomain.json": {


### PR DESCRIPTION
Issue: Request to aws config endpoint returning a 404 when jupyter notebook base url is defined and non-"/". aws-jupyter-proxy uses jupyter notebook base url as prefix to its api endpoints (https://github.com/aws/aws-jupyter-proxy/blob/master/aws_jupyter_proxy/handlers.py#L26)

Solution: Adds base url in request to aws config endpoint