### PR TITLE
Added jupyterlab version to DOM

### DIFF
--- a/lib/LeftSideLauncher.d.ts
+++ b/lib/LeftSideLauncher.d.ts
@@ -17,5 +17,5 @@ export declare class LuminoLeftSideLauncher extends LuminoWidget {
     handleLaunchButtonClicked(): undefined;
 }
 export declare class LeftSideLauncher {
-    static create(version: number, commands: PhosphorCommandRegistry | LuminoCommandRegistry): PhosphorLeftSideLauncher | LuminoLeftSideLauncher;
+    static create(version: string, commands: PhosphorCommandRegistry | LuminoCommandRegistry): PhosphorLeftSideLauncher | LuminoLeftSideLauncher;
 }

--- a/lib/LeftSideLauncher.js
+++ b/lib/LeftSideLauncher.js
@@ -15,7 +15,8 @@ export class LuminoLeftSideLauncher extends LuminoWidget {
 }
 export class LeftSideLauncher {
     static create(version, commands) {
-        const widget = version === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
+        const majorVersion = Number(version.split(".")[0]);
+        const widget = majorVersion === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
         widget.commands = commands;
         const launchButton = document.createElement("div");
         const header = document.createElement("header");

--- a/lib/MainLauncher.d.ts
+++ b/lib/MainLauncher.d.ts
@@ -22,5 +22,5 @@ export declare class LuminoMainLauncher extends LuminoWidget {
     cssPath: string;
 }
 export declare class MainLauncher {
-    static create(version: number, baseUrl: string, cssPath: string, region: AWSRegion): PhosphorMainLauncher | LuminoMainLauncher;
+    static create(version: string, baseUrl: string, cssPath: string, region: AWSRegion): PhosphorMainLauncher | LuminoMainLauncher;
 }

--- a/lib/MainLauncher.js
+++ b/lib/MainLauncher.js
@@ -6,7 +6,8 @@ export class LuminoMainLauncher extends LuminoWidget {
 }
 export class MainLauncher {
     static create(version, baseUrl, cssPath, region) {
-        const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
+        const majorVersion = Number(version.split(".")[0]);
+        const widget = majorVersion === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
         widget.cssPath = cssPath;
         widget.id = "aws_glue_databrew_jupyter";
         widget.title.label = "AWS Glue DataBrew";
@@ -19,6 +20,7 @@ export class MainLauncher {
           <meta charset="UTF-8">
           <meta name="awsc-lang" content="en">
           <meta id="jupyter-server-base-url" content="${baseUrl}">
+          <meta id="jupyterlab-version" content="${version}">
           <meta name="aws-glue-databrew-jupyter" content="true">
           <meta id="aws-glue-databrew-jupyter-region" content="${region || ""}">
           <title>AWS</title>

--- a/lib/aws_glue_databrew_extension.js
+++ b/lib/aws_glue_databrew_extension.js
@@ -5,7 +5,7 @@ import { getAWSConfig } from "./client";
 import { GLUE_DATABREW_RENDER } from "./constants";
 import { LeftSideLauncher } from "./LeftSideLauncher";
 import { MainLauncher } from "./MainLauncher";
-const getAppVersion = (app) => Number(app.version.split(".")[0]);
+const getAppVersion = (app) => app.version;
 const getBaseUrl = (app) => app.serviceManager.serverSettings.baseUrl;
 /**
  * Initialize the console widget extension

--- a/src/LeftSideLauncher.ts
+++ b/src/LeftSideLauncher.ts
@@ -27,8 +27,9 @@ export class LuminoLeftSideLauncher extends LuminoWidget {
 }
 
 export class LeftSideLauncher {
-  static create(version: number, commands: PhosphorCommandRegistry | LuminoCommandRegistry): PhosphorLeftSideLauncher | LuminoLeftSideLauncher {
-    const widget = version === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
+  static create(version: string, commands: PhosphorCommandRegistry | LuminoCommandRegistry): PhosphorLeftSideLauncher | LuminoLeftSideLauncher {
+    const majorVersion = Number(version.split(".")[0]);
+    const widget = majorVersion === 1 ? new PhosphorLeftSideLauncher() : new LuminoLeftSideLauncher();
     widget.commands = commands;
 
     const launchButton = document.createElement("div");

--- a/src/MainLauncher.ts
+++ b/src/MainLauncher.ts
@@ -1,7 +1,6 @@
 import { Widget as PhosphorWidget } from "@phosphor/widgets";
 import { Widget as LuminoWidget } from "@lumino/widgets";
 import { AWSRegion } from "./types";
-
 export class PhosphorMainLauncher extends PhosphorWidget {
   /**
    * The image element associated with the widget.
@@ -25,8 +24,9 @@ export class LuminoMainLauncher extends LuminoWidget {
 }
 
 export class MainLauncher {
-  static create(version: number, baseUrl: string, cssPath: string, region: AWSRegion): PhosphorMainLauncher | LuminoMainLauncher {
-    const widget = version === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
+  static create(version: string, baseUrl: string, cssPath: string, region: AWSRegion): PhosphorMainLauncher | LuminoMainLauncher {
+    const majorVersion = Number(version.split(".")[0]);
+    const widget = majorVersion === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
 
     widget.cssPath = cssPath;
     widget.id = "aws_glue_databrew_jupyter";
@@ -43,6 +43,7 @@ export class MainLauncher {
           <meta charset="UTF-8">
           <meta name="awsc-lang" content="en">
           <meta id="jupyter-server-base-url" content="${baseUrl}">
+          <meta id="jupyterlab-version" content="${version}">
           <meta name="aws-glue-databrew-jupyter" content="true">
           <meta id="aws-glue-databrew-jupyter-region" content="${region || ""}">
           <title>AWS</title>

--- a/src/aws_glue_databrew_extension.ts
+++ b/src/aws_glue_databrew_extension.ts
@@ -9,7 +9,7 @@ import { GLUE_DATABREW_RENDER } from "./constants";
 import { LeftSideLauncher } from "./LeftSideLauncher";
 import { MainLauncher } from "./MainLauncher";
 
-const getAppVersion = (app: JupyterFrontEnd) => Number(app.version.split(".")[0]);
+const getAppVersion = (app: JupyterFrontEnd) => app.version;
 const getBaseUrl = (app: JupyterFrontEnd) => app.serviceManager.serverSettings.baseUrl;
 
 /**

--- a/tests/LeftSideLauncher.test.ts
+++ b/tests/LeftSideLauncher.test.ts
@@ -3,7 +3,7 @@ import { LeftSideLauncher } from "../src/LeftSideLauncher";
 
 describe("LeftSideLauncher", () => {
   describe("create", () => {
-    test.each([[1], [2]])("should create launcher v%s", (version) => {
+    test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s", (version) => {
       const execute = jest.fn(() => undefined);
       const command: Partial<CommandRegistry> = { execute };
       const widget = LeftSideLauncher.create(version, command as CommandRegistry);

--- a/tests/MainLauncher.test.ts
+++ b/tests/MainLauncher.test.ts
@@ -3,7 +3,7 @@ import { AWSRegion } from "../src/types";
 
 describe("MainLauncher", () => {
   describe("create", () => {
-    test.each([[1], [2]])("should create launcher v%s", (version) => {
+    test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s", (version) => {
       const baseUrl = "/";
       const region = "us-east-1";
       const cssPath = "path";
@@ -15,7 +15,7 @@ describe("MainLauncher", () => {
       expect(widget.node).toMatchSnapshot();
     });
 
-    test.each([[1], [2]])("should create launcher v%s with undefined region", (version) => {
+    test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s with undefined region", (version) => {
       const baseUrl = "/";
       const region: AWSRegion = undefined;
       const cssPath = "path";
@@ -27,7 +27,7 @@ describe("MainLauncher", () => {
       expect(widget.node).toMatchSnapshot();
     });
 
-    test.each([[1], [2]])("should create launcher v%s with null region", (version) => {
+    test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s with null region", (version) => {
       const baseUrl = "/";
       const region: AWSRegion = null;
       const cssPath = "path";

--- a/tests/__snapshots__/LeftSideLauncher.test.ts.snap
+++ b/tests/__snapshots__/LeftSideLauncher.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LeftSideLauncher create should create launcher v1 1`] = `
+exports[`LeftSideLauncher create should create launcher v1.0.0 1`] = `
 <div
   class="p-Widget"
   id="aws_glue_databrew_jupyter_left_side_launcher"
@@ -19,7 +19,7 @@ exports[`LeftSideLauncher create should create launcher v1 1`] = `
 </div>
 `;
 
-exports[`LeftSideLauncher create should create launcher v2 1`] = `
+exports[`LeftSideLauncher create should create launcher v2.0.0 1`] = `
 <div
   class="lm-Widget p-Widget"
   id="aws_glue_databrew_jupyter_left_side_launcher"

--- a/tests/__snapshots__/MainLauncher.test.ts.snap
+++ b/tests/__snapshots__/MainLauncher.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MainLauncher create should create launcher v1 1`] = `
+exports[`MainLauncher create should create launcher v1.0.0 1`] = `
 <div
   class="p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -25,6 +25,12 @@ exports[`MainLauncher create should create launcher v1 1`] = `
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="1.0.0"
+      id="jupyterlab-version"
     />
     
           
@@ -127,7 +133,7 @@ exports[`MainLauncher create should create launcher v1 1`] = `
 </div>
 `;
 
-exports[`MainLauncher create should create launcher v1 with null region 1`] = `
+exports[`MainLauncher create should create launcher v1.0.0 with null region 1`] = `
 <div
   class="p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -152,6 +158,12 @@ exports[`MainLauncher create should create launcher v1 with null region 1`] = `
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="1.0.0"
+      id="jupyterlab-version"
     />
     
           
@@ -254,7 +266,7 @@ exports[`MainLauncher create should create launcher v1 with null region 1`] = `
 </div>
 `;
 
-exports[`MainLauncher create should create launcher v1 with undefined region 1`] = `
+exports[`MainLauncher create should create launcher v1.0.0 with undefined region 1`] = `
 <div
   class="p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -279,6 +291,12 @@ exports[`MainLauncher create should create launcher v1 with undefined region 1`]
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="1.0.0"
+      id="jupyterlab-version"
     />
     
           
@@ -381,7 +399,7 @@ exports[`MainLauncher create should create launcher v1 with undefined region 1`]
 </div>
 `;
 
-exports[`MainLauncher create should create launcher v2 1`] = `
+exports[`MainLauncher create should create launcher v2.0.0 1`] = `
 <div
   class="lm-Widget p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -406,6 +424,12 @@ exports[`MainLauncher create should create launcher v2 1`] = `
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="2.0.0"
+      id="jupyterlab-version"
     />
     
           
@@ -508,7 +532,7 @@ exports[`MainLauncher create should create launcher v2 1`] = `
 </div>
 `;
 
-exports[`MainLauncher create should create launcher v2 with null region 1`] = `
+exports[`MainLauncher create should create launcher v2.0.0 with null region 1`] = `
 <div
   class="lm-Widget p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -533,6 +557,12 @@ exports[`MainLauncher create should create launcher v2 with null region 1`] = `
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="2.0.0"
+      id="jupyterlab-version"
     />
     
           
@@ -635,7 +665,7 @@ exports[`MainLauncher create should create launcher v2 with null region 1`] = `
 </div>
 `;
 
-exports[`MainLauncher create should create launcher v2 with undefined region 1`] = `
+exports[`MainLauncher create should create launcher v2.0.0 with undefined region 1`] = `
 <div
   class="lm-Widget p-Widget"
   id="aws_glue_databrew_jupyter"
@@ -660,6 +690,12 @@ exports[`MainLauncher create should create launcher v2 with undefined region 1`]
     <meta
       content="/"
       id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="2.0.0"
+      id="jupyterlab-version"
     />
     
           

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1666,15 +1666,15 @@
         "signature": "ce75ab9766be65e1b6837cba39ea25ebfbe25f431e0f97e1863743817fad2d91"
       },
       "./src/leftsidelauncher.ts": {
-        "version": "5b4375923d3d269cfc601d07c00b19face2564803f6595576fad89ee585b42c3",
-        "signature": "c9c5e764f2a5482546c1c4fb40c310263397ff5c53069e1f485ae55eea498abc"
+        "version": "641f10537fa6889d87784c5f6f1cf7144523401fa5afa71260eefb4550a49d8a",
+        "signature": "c8b3fe3bdcefb775c619133ab055fcaf06453ea6fddad87083fb26ccedeb6fda"
       },
       "./src/mainlauncher.ts": {
-        "version": "fee43110b56cd91c3f875a533a8a5f144e890ba481f7c9785319a72950bc2dae",
-        "signature": "63381bcdae9c1db9ed8996e5194c37193906891e8759e61a1ea46ff8549a19e0"
+        "version": "b659f7bc73e492b264ae3ff7e0e484199220ce40428dfcd48421460a2e958691",
+        "signature": "8b58ba85c9ba6fe94f364347f20d673f9669bb2474f45935375c84df2e94dde7"
       },
       "./src/aws_glue_databrew_extension.ts": {
-        "version": "7db99f94d93b99b3ce6d734250e376b9eb787929ee1ebe6b8fe33502755a9da3",
+        "version": "a9163cc4803cfa043990b3c9483207cca4aa006bf4ad9f9fdae91c182ceb5492",
         "signature": "9253a39dd2652b931dcd5d7d788afbaf995ceb27ff8e268084603f93e1cf0a60"
       },
       "./src/index.ts": {


### PR DESCRIPTION
This change is to allow the plugin to add a new meta tag that contains the jupyterlab version. This is particularly helpful for AWS Glue DataBrew console metrics to emit messages with this metadata.