### PR TITLE
Assets source and branding changes for CN regions

### DIFF
--- a/src/MainLauncher.ts
+++ b/src/MainLauncher.ts
@@ -1,6 +1,7 @@
 import { Widget as PhosphorWidget } from "@phosphor/widgets";
 import { Widget as LuminoWidget } from "@lumino/widgets";
 import { AWSRegion } from "./types";
+import { isCnPartition } from "./utils";
 export class PhosphorMainLauncher extends PhosphorWidget {
   /**
    * The image element associated with the widget.
@@ -28,9 +29,10 @@ export class MainLauncher {
     const majorVersion = Number(version.split(".")[0]);
     const widget = majorVersion === 1 ? new PhosphorMainLauncher() : new LuminoMainLauncher();
 
+    const awsText = isCnPartition(region) ? "Amazon" : "AWS";
     widget.cssPath = cssPath;
     widget.id = "aws_glue_databrew_jupyter";
-    widget.title.label = "AWS Glue DataBrew";
+    widget.title.label = `${awsText} Glue DataBrew`;
     widget.title.closable = true;
 
     widget.consoleRoot = document.createElement("html");
@@ -87,7 +89,7 @@ export class MainLauncher {
           <div id="app" style="height: 100%">
             <div class="loader-container">
               <div>
-                <div class="loader"></div><span>Launching AWS Glue DataBrew</span>
+                <div class="loader"></div><span>Launching ${awsText} Glue DataBrew</span>
               </div>
             </div>
           </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,7 @@
 import { subdomain } from "./subdomain.json";
 
 export const GLUE_DATABREW_RENDER = "gluedatabrew:render";
+export const CN_REGION_HOST = "https://elixir-console-assets-prod-bjs.s3.cn-north-1.amazonaws.com.cn"
 export const CLOUDFRONT_HOST = `https://${subdomain}.cloudfront.net`;
-export const CONTENT_PREFIX = CLOUDFRONT_HOST + "/content";
-export const PREFIX_URL = CLOUDFRONT_HOST + "/prefixes/main";
 export const jsFileName = "main.js";
 export const styleFileName = "styles.css";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,23 @@
 import { initiateExtension } from "./aws_glue_databrew_extension";
 import {
-  CONTENT_PREFIX,
-  jsFileName,
-  PREFIX_URL,
-  styleFileName,
-} from "./constants";
+  getContentPrefixUrl,
+  getPrefixUrl,
+} from "./utils";
+import { jsFileName, styleFileName } from "./constants";
 
-export const getPaths = async (): Promise<string[]> => {
-  const prefix = await getPrefix();
+export const getPaths = async (region: string): Promise<string[]> => {
+  const prefix = await getPrefix(region);
+  const contentPrefixUrl = `${getContentPrefixUrl(region)}/${prefix}`;
   return [
-    `${CONTENT_PREFIX}/${prefix}/${jsFileName}`,
-    `${CONTENT_PREFIX}/${prefix}/${styleFileName}`,
+    `${contentPrefixUrl}/${jsFileName}`,
+    `${contentPrefixUrl}/${styleFileName}`,
   ];
 };
 
-export const getPrefix = async (): Promise<string> => {
-  const response = await fetch(PREFIX_URL);
+export const getPrefix = async (region: string): Promise<string> => {
+  const prefixUrl = getPrefixUrl(region);
+  const req = new Request(prefixUrl);
+  const response = await fetch(req);
   const json = await response.json();
   return json && json.prefix.toString();
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+import { CLOUDFRONT_HOST, CN_REGION_HOST } from "./constants";
+
+export const isCnPartition = (region: string): boolean => region === "cn-north-1" || region === "cn-northwest-1";
+export const getBaseUrl = (region: string): string => isCnPartition(region) ? CN_REGION_HOST : CLOUDFRONT_HOST
+export const getContentPrefixUrl = (region: string): string => `${getBaseUrl(region)}/content`;
+export const getPrefixUrl = (region: string): string => `${getBaseUrl(region)}/prefixes/main`;

--- a/tests/MainLauncher.test.ts
+++ b/tests/MainLauncher.test.ts
@@ -15,6 +15,18 @@ describe("MainLauncher", () => {
       expect(widget.node).toMatchSnapshot();
     });
 
+    test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s in CN region", (version) => {
+      const baseUrl = "/";
+      const region = "cn-north-1";
+      const cssPath = "path";
+      const widget = MainLauncher.create(version, baseUrl, cssPath, region);
+      expect(widget.cssPath).toEqual(cssPath);
+      expect(widget.id).toEqual("aws_glue_databrew_jupyter");
+      expect(widget.title.label).toEqual("Amazon Glue DataBrew");
+      expect(widget.title.closable).toEqual(true);
+      expect(widget.node).toMatchSnapshot();
+    });
+
     test.each([["1.0.0"], ["2.0.0"]])("should create launcher v%s with undefined region", (version) => {
       const baseUrl = "/";
       const region: AWSRegion = undefined;

--- a/tests/__snapshots__/MainLauncher.test.ts.snap
+++ b/tests/__snapshots__/MainLauncher.test.ts.snap
@@ -133,6 +133,139 @@ exports[`MainLauncher create should create launcher v1.0.0 1`] = `
 </div>
 `;
 
+exports[`MainLauncher create should create launcher v1.0.0 in CN region 1`] = `
+<div
+  class="p-Widget"
+  id="aws_glue_databrew_jupyter"
+>
+  <html
+    style="height: 100%"
+  >
+    
+        
+          
+    <meta
+      charset="UTF-8"
+    />
+    
+          
+    <meta
+      content="en"
+      name="awsc-lang"
+    />
+    
+          
+    <meta
+      content="/"
+      id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="1.0.0"
+      id="jupyterlab-version"
+    />
+    
+          
+    <meta
+      content="true"
+      name="aws-glue-databrew-jupyter"
+    />
+    
+          
+    <meta
+      content="cn-north-1"
+      id="aws-glue-databrew-jupyter-region"
+    />
+    
+          
+    <title>
+      AWS
+    </title>
+    
+          
+    <link
+      href="path"
+      rel="stylesheet"
+    />
+    
+          
+    <style>
+      
+            .loader {
+              display: inline-block;
+              border: 5px solid #f3f3f3;
+              border-radius: 50%;
+              border-top: 5px solid #3498db;
+              width: 40px;
+              height: 40px;
+              margin-right: 12px;
+              -webkit-animation: spin 2s linear infinite;
+              animation: spin 2s linear infinite;
+            }
+
+            @-webkit-keyframes spin {
+              0% { -webkit-transform: rotate(0deg); }
+              100% { -webkit-transform: rotate(360deg); }
+            }
+
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+
+            .loader-container {
+              font-size: 60px;
+              font-weight: 100;
+              color: #879196;
+              height: 100%;
+              width: 100%;
+              justify-content: center;
+              display: flex;
+              align-items: center;
+            }
+          
+    </style>
+    
+        
+        
+          
+    <div
+      id="app"
+      style="height: 100%"
+    >
+      
+            
+      <div
+        class="loader-container"
+      >
+        
+              
+        <div>
+          
+                
+          <div
+            class="loader"
+          />
+          <span>
+            Launching Amazon Glue DataBrew
+          </span>
+          
+              
+        </div>
+        
+            
+      </div>
+      
+          
+    </div>
+    
+        
+    
+  </html>
+</div>
+`;
+
 exports[`MainLauncher create should create launcher v1.0.0 with null region 1`] = `
 <div
   class="p-Widget"
@@ -515,6 +648,139 @@ exports[`MainLauncher create should create launcher v2.0.0 1`] = `
           />
           <span>
             Launching AWS Glue DataBrew
+          </span>
+          
+              
+        </div>
+        
+            
+      </div>
+      
+          
+    </div>
+    
+        
+    
+  </html>
+</div>
+`;
+
+exports[`MainLauncher create should create launcher v2.0.0 in CN region 1`] = `
+<div
+  class="lm-Widget p-Widget"
+  id="aws_glue_databrew_jupyter"
+>
+  <html
+    style="height: 100%"
+  >
+    
+        
+          
+    <meta
+      charset="UTF-8"
+    />
+    
+          
+    <meta
+      content="en"
+      name="awsc-lang"
+    />
+    
+          
+    <meta
+      content="/"
+      id="jupyter-server-base-url"
+    />
+    
+          
+    <meta
+      content="2.0.0"
+      id="jupyterlab-version"
+    />
+    
+          
+    <meta
+      content="true"
+      name="aws-glue-databrew-jupyter"
+    />
+    
+          
+    <meta
+      content="cn-north-1"
+      id="aws-glue-databrew-jupyter-region"
+    />
+    
+          
+    <title>
+      AWS
+    </title>
+    
+          
+    <link
+      href="path"
+      rel="stylesheet"
+    />
+    
+          
+    <style>
+      
+            .loader {
+              display: inline-block;
+              border: 5px solid #f3f3f3;
+              border-radius: 50%;
+              border-top: 5px solid #3498db;
+              width: 40px;
+              height: 40px;
+              margin-right: 12px;
+              -webkit-animation: spin 2s linear infinite;
+              animation: spin 2s linear infinite;
+            }
+
+            @-webkit-keyframes spin {
+              0% { -webkit-transform: rotate(0deg); }
+              100% { -webkit-transform: rotate(360deg); }
+            }
+
+            @keyframes spin {
+              0% { transform: rotate(0deg); }
+              100% { transform: rotate(360deg); }
+            }
+
+            .loader-container {
+              font-size: 60px;
+              font-weight: 100;
+              color: #879196;
+              height: 100%;
+              width: 100%;
+              justify-content: center;
+              display: flex;
+              align-items: center;
+            }
+          
+    </style>
+    
+        
+        
+          
+    <div
+      id="app"
+      style="height: 100%"
+    >
+      
+            
+      <div
+        class="loader-container"
+      >
+        
+              
+        <div>
+          
+                
+          <div
+            class="loader"
+          />
+          <span>
+            Launching Amazon Glue DataBrew
           </span>
           
               

--- a/tests/aws_glue_databrew_extension.test.ts
+++ b/tests/aws_glue_databrew_extension.test.ts
@@ -67,6 +67,54 @@ describe("initiateExtension", () => {
       expect(launcher.add).toHaveBeenCalledTimes(1);
     });
 
+    test("should activate plugin in cn region", async () => {
+      const getPaths = jest.fn().mockReturnValueOnce(Promise.resolve(["main.js", "styles.css"]));
+      jest.spyOn(MainLauncher, "create").mockReturnValueOnce(new LuminoMainLauncher());
+      jest.spyOn(LeftSideLauncher, "create").mockReturnValueOnce(new LuminoLeftSideLauncher());
+      jest.spyOn(client, "getAWSConfig").mockReturnValueOnce(Promise.resolve({
+        region: "cn-north-1",
+      }));
+      const extension = plugin.initiateExtension(getPaths);
+      const commands: Partial<CommandRegistry> = {
+        addCommand: jest.fn(),
+      };
+      const serviceManager = {
+        serverSettings: {
+          baseUrl: "http://localhost:8888/",
+        } as ServerConnection.ISettings,
+      } as ServiceManager;
+      const shell: Partial<JupyterFrontEnd.IShell> = {
+        add: jest.fn(),
+        activateById: jest.fn(),
+      };
+      const app: Partial<JupyterFrontEnd>  = {
+        commands: commands as CommandRegistry,
+        shell: shell as JupyterFrontEnd.IShell,
+        serviceManager,
+        version: "1.0.0",
+      };
+      const palette: Partial<ICommandPalette> = {
+        addItem: jest.fn(),
+      };
+      const restorer: Partial<ILayoutRestorer> = {
+        add: jest.fn(),
+      };
+      const launcher: Partial<ILauncher> = {
+        add: jest.fn(),
+      };
+      await extension.activate(
+        app as JupyterFrontEnd,
+        palette,
+        restorer,
+        launcher,
+      );
+      expect(getPaths).toHaveBeenCalledTimes(1);
+      expect(commands.addCommand).toHaveBeenCalledTimes(1);
+      expect(palette.addItem).toHaveBeenCalledTimes(1);
+      expect(shell.add).toHaveBeenCalledTimes(1);
+      expect(launcher.add).toHaveBeenCalledTimes(1);
+    });
+
     test("should activate plugin without launcher", async () => {
       const getPaths = jest.fn().mockReturnValueOnce(Promise.resolve(["main.js", "styles.css"]));
       jest.spyOn(MainLauncher, "create").mockReturnValueOnce(new LuminoMainLauncher());

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,12 +6,25 @@ describe("index", () => {
       jest
         .spyOn(plugin, "getPrefix")
         .mockReturnValueOnce(Promise.resolve("prefix"));
-      const [js, css] = await plugin.getPaths();
+      const [js, css] = await plugin.getPaths("us-west-1");
       expect(js).toBe(
         "https://dc69wn9dwut4o.cloudfront.net/content/prefix/main.js"
       );
       expect(css).toBe(
         "https://dc69wn9dwut4o.cloudfront.net/content/prefix/styles.css"
+      );
+    });
+
+    test("should return paths in cn region", async () => {
+      jest
+        .spyOn(plugin, "getPrefix")
+        .mockReturnValueOnce(Promise.resolve("prefix"));
+      const [js, css] = await plugin.getPaths("cn-north-1");
+      expect(js).toBe(
+        "https://elixir-console-assets-prod-bjs.s3.cn-north-1.amazonaws.com.cn/content/prefix/main.js"
+      );
+      expect(css).toBe(
+        "https://elixir-console-assets-prod-bjs.s3.cn-north-1.amazonaws.com.cn/content/prefix/styles.css"
       );
     });
   });
@@ -26,7 +39,20 @@ describe("index", () => {
         })
       );
       jest.spyOn(window, "fetch").mockImplementationOnce(mockFetch);
-      const prefix = await plugin.getPrefix();
+      const prefix = await plugin.getPrefix("us-west-1");
+      expect(prefix).toBe("asdf");
+    });
+
+    test("should return valid prefix in cn region", async () => {
+      const json = { prefix: "asdf" };
+      const mockJson = jest.fn().mockReturnValueOnce(Promise.resolve(json));
+      const mockFetch = jest.fn().mockReturnValueOnce(
+        Promise.resolve({
+          json: mockJson,
+        })
+      );
+      jest.spyOn(window, "fetch").mockImplementationOnce(mockFetch);
+      const prefix = await plugin.getPrefix("cn-north-1");
       expect(prefix).toBe("asdf");
     });
 
@@ -40,7 +66,7 @@ describe("index", () => {
         })
       );
       jest.spyOn(window, "fetch").mockImplementationOnce(mockFetch);
-      const prefix = await plugin.getPrefix();
+      const prefix = await plugin.getPrefix("us-west-1");
       expect(prefix).toBe(undefined);
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "src/constants.ts",
     "src/client.ts",
     "src/types.ts",
-    "src/subdomain.json"
+    "src/subdomain.json",
+    "src/utils.ts"
   ]
 }


### PR DESCRIPTION
Load jupyter assets from CN regions from cn-north-1, replace AWS branding with Amazon branding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
